### PR TITLE
[SETTING] 애플 로그인 세팅 및 카카오 로그인 키 값 변경 #9

### DIFF
--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		F49B352B2B35EAF50080A19F /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		F49B352D2B35EB270080A19F /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		F49B35302B35EC760080A19F /* Codable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Codable+.swift"; sourceTree = "<group>"; };
+		F4D0416E2B415EDB00B94FEE /* Going-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Going-iOS.entitlements"; sourceTree = "<group>"; };
 		F4F521712B3440D7000E6E1E /* Going-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Going-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4F521742B3440D7000E6E1E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F4F521762B3440D7000E6E1E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -99,6 +100,7 @@
 		F4F521732B3440D7000E6E1E /* Going-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				F4D0416E2B415EDB00B94FEE /* Going-iOS.entitlements */,
 				F4F5219A2B3467FD000E6E1E /* Scene */,
 				F4F521962B346760000E6E1E /* Network */,
 				F4F521882B344ED1000E6E1E /* Application */,
@@ -533,6 +535,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Going-iOS/Going-iOS.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -553,7 +557,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Going.Going-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = DooripDevelop;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = DooripDevelopment;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -566,6 +570,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Going-iOS/Going-iOS.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Going-iOS/Application/AppDelegate.swift
+++ b/Going-iOS/Application/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import KakaoSDKCommon
+import AuthenticationServices
 
 
 @main
@@ -17,6 +18,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         let kakaoNativeAppKey = Config.kakaoNativeAppKey
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
+        
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        appleIDProvider.getCredentialState(forUserID: "여기에 credential.user 넣기") { (credentialState, error) in
+            switch credentialState {
+                case .authorized:
+                   print("authorized")
+                   // The Apple ID credential is valid.
+//                   DispatchQueue.main.async {
+//                     //authorized된 상태이므로 바로 로그인 완료 화면으로 이동
+//                     self.window?.rootViewController = ViewController()
+//                   }
+                case .revoked:
+                   print("revoked")
+                case .notFound:
+                   // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
+                   print("notFound")
+                       
+                default:
+                    break
+            }
+        }
         
         return true
     }

--- a/Going-iOS/Application/SceneDelegate.swift
+++ b/Going-iOS/Application/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import KakaoSDKAuth
+import AuthenticationServices
 
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -30,6 +31,29 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let url = URLContexts.first?.url {
             if (AuthApi.isKakaoTalkLoginUrl(url)) {
                 _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        appleIDProvider.getCredentialState(forUserID: "여기에 credential.user 넣기") { (credentialState, error) in
+            switch credentialState {
+                case .authorized:
+                   print("authorized")
+                   // The Apple ID credential is valid.
+//                   DispatchQueue.main.async {
+//                     //authorized된 상태이므로 바로 로그인 완료 화면으로 이동
+//                     self.window?.rootViewController = ViewController()
+//                   }
+                case .revoked:
+                   print("revoked")
+                case .notFound:
+                   // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
+                   print("notFound")
+                       
+                default:
+                    break
             }
         }
     }

--- a/Going-iOS/Global/Settings/Configurations/Development.xcconfig
+++ b/Going-iOS/Global/Settings/Configurations/Development.xcconfig
@@ -9,4 +9,4 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 //Key
-KAKAO_NATIVE_APP_KEY = c6a0092a12910c9bf6c4149183d53f1f
+KAKAO_NATIVE_APP_KEY = e3061837289ad2e10006ec957af4a1b3

--- a/Going-iOS/Going-iOS.entitlements
+++ b/Going-iOS/Going-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Going-iOS/ViewController.swift
+++ b/Going-iOS/ViewController.swift
@@ -10,58 +10,106 @@ import UIKit
 import KakaoSDKAuth
 import KakaoSDKUser
 import SnapKit
+import AuthenticationServices
 
 final class ViewController: UIViewController {
-
+    
     private lazy var kakaoLoginButton: UIButton = {
-            let button = UIButton()
-            button.setTitle("카카오로그인하기", for: .normal)
-            button.setTitleColor(.black, for: .normal)
-            button.backgroundColor = .yellow
-            button.layer.cornerRadius = 25
-            button.clipsToBounds = true
-            button.addTarget(self, action: #selector(kakaoLoginButtonTapped), for: .touchUpInside)
-            return button
-        }()
-
-        override func viewDidLoad() {
-            super.viewDidLoad()
-            setLayout()
+        let button = UIButton()
+        button.setTitle("카카오로그인하기", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.backgroundColor = .yellow
+        button.layer.cornerRadius = 25
+        button.clipsToBounds = true
+        button.addTarget(self, action: #selector(kakaoLoginButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var appleLoginButton: ASAuthorizationAppleIDButton = {
+        let button = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: .white)
+        button.addTarget(self, action: #selector(appleLoginButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setLayout()
+    }
+    
+    private func setLayout() {
+        view.addSubviews(kakaoLoginButton, appleLoginButton)
+        kakaoLoginButton.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
-
-        private func setLayout() {
-            view.addSubview(kakaoLoginButton)
-            kakaoLoginButton.snp.makeConstraints { make in
-                make.center.equalToSuperview()
-            }
+        
+        appleLoginButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(kakaoLoginButton.snp.bottom).offset(200)
         }
-
-        @objc func kakaoLoginButtonTapped() {
-            if UserApi.isKakaoTalkLoginAvailable() {
-                loginKakaoWithApp()
-            } else {
-                loginKakaoWithWeb()
-            }
+    }
+    
+    @objc
+    private func appleLoginButtonTapped() {
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        controller.performRequests()
+        
+    }
+    
+    @objc
+    func kakaoLoginButtonTapped() {
+        if UserApi.isKakaoTalkLoginAvailable() {
+            loginKakaoWithApp()
+        } else {
+            loginKakaoWithWeb()
         }
-
-        private func loginKakaoWithApp() {
-            UserApi.shared.loginWithKakaoTalk { oAuthToken, error in
-                guard error == nil else { return }
-                print("Login with KAKAO App Success !!")
-                guard let oAuthToken = oAuthToken else { return }
-                print(oAuthToken.accessToken)
-            }
+    }
+    
+    private func loginKakaoWithApp() {
+        UserApi.shared.loginWithKakaoTalk { oAuthToken, error in
+            guard error == nil else { return }
+            print("Login with KAKAO App Success !!")
+            guard let oAuthToken = oAuthToken else { return }
+            print(oAuthToken.accessToken)
         }
-
-        private func loginKakaoWithWeb() {
-            UserApi.shared.loginWithKakaoAccount { oAuthToken, error in
-                guard error == nil else { return }
-                print("Login with KAKAO Web Success !!")
-                guard let oAuthToken = oAuthToken else { return }
-                print(oAuthToken.accessToken)
-            }
+    }
+    
+    private func loginKakaoWithWeb() {
+        UserApi.shared.loginWithKakaoAccount { oAuthToken, error in
+            guard error == nil else { return }
+            print("Login with KAKAO Web Success !!")
+            guard let oAuthToken = oAuthToken else { return }
+            print(oAuthToken.accessToken)
         }
-
-
+    }
 }
 
+extension ViewController: ASAuthorizationControllerDelegate {
+    //애플로그인 성공했을 때
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        
+        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            //이거로 자동로그인 판별
+            let userIdentifier = credential.user
+            
+            // .authorizationCode와 .identityToken은 Generate and valid tokens, revoke tokens에서 사용
+            
+        }
+    }
+    
+    //애플로그인 실패했을 때
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("login failed - \(error.localizedDescription)")
+
+    }
+}
+
+extension ViewController: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+    
+    
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#9

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 애플 로그인 세팅
- 카카오 로그인 키 값 변경
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 애플 로그인을 했을 때, user의 id를 가지고 스플래시에서 어디로 보낼 지 판별을 해야되는데, appDelegate에서 해야 될 지, sceneDelegate에서 해야 될 지 고민중입니다.
- AppDelegate의 didFinishLaunchingWithOptions에서 구현해 놓는 것이 일반적
- 하지만 사용 도중 revoke가 될 것을 고려한다면, SceneDelegate의 sceneDidBecomeActive() 에도 구현해놓는 것이 좋을 듯?

- 그리고 ViewController 는 현재 테스트용도의 VC입니다. 추후에 삭제할 예정입니다.
## 📟 관련 이슈
- Resolved: #9
