### PR TITLE
[FEAT] 프로필완성뷰 UI 구현 및 성향테스트 결과 데이터더미 생성 (#32)

### DIFF
--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		CA8CD6A22B4803B200CFDFBF /* ToDoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD6A12B4803B200CFDFBF /* ToDoData.swift */; };
 		CA8CD6A42B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */; };
 		CA8CD6A82B483FD000CFDFBF /* DoubleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD6A72B483FD000CFDFBF /* DoubleButtonView.swift */; };
+		F430A9832B4AAEA900D482C4 /* CompleteProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */; };
 		F484A3852B3EBC2A00197E3C /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F484A3842B3EBC2A00197E3C /* UIColor+.swift */; };
 		F485D4892B47CB8B007317F4 /* UserTestSplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F485D4882B47CB8B007317F4 /* UserTestSplashViewController.swift */; };
 		F485D48D2B47CF58007317F4 /* UserTestQuestionStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = F485D48C2B47CF58007317F4 /* UserTestQuestionStruct.swift */; };
@@ -136,6 +137,7 @@
 		CA8CD6A12B4803B200CFDFBF /* ToDoData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoData.swift; sourceTree = "<group>"; };
 		CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoManagerCollectionViewCell.swift; sourceTree = "<group>"; };
 		CA8CD6A72B483FD000CFDFBF /* DoubleButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleButtonView.swift; sourceTree = "<group>"; };
+		F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteProfileViewController.swift; sourceTree = "<group>"; };
 		F484A3842B3EBC2A00197E3C /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		F485D4882B47CB8B007317F4 /* UserTestSplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTestSplashViewController.swift; sourceTree = "<group>"; };
 		F485D48C2B47CF58007317F4 /* UserTestQuestionStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTestQuestionStruct.swift; sourceTree = "<group>"; };
@@ -348,6 +350,38 @@
 			path = ViewControllers;
 			sourceTree = "<group>";
 		};
+		CA8CD69B2B47F5AC00CFDFBF /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				CA8CD6A12B4803B200CFDFBF /* ToDoData.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		CA8CD69C2B47F5BE00CFDFBF /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		F430A9812B4AAE4D00D482C4 /* CompleteProfile */ = {
+			isa = PBXGroup;
+			children = (
+				F430A9842B4ABFC200D482C4 /* ViewControllers */,
+			);
+			path = CompleteProfile;
+			sourceTree = "<group>";
+		};
+		F430A9842B4ABFC200D482C4 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
 		F485D4872B47CB43007317F4 /* UserTest */ = {
 			isa = PBXGroup;
 			children = (
@@ -366,14 +400,6 @@
 			path = ViewControllers;
 			sourceTree = "<group>";
 		};
-		CA8CD69B2B47F5AC00CFDFBF /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				CA8CD6A12B4803B200CFDFBF /* ToDoData.swift */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
 		F485D48B2B47CF15007317F4 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -382,28 +408,20 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		CA8CD69C2B47F5BE00CFDFBF /* Cells */ = {
-			isa = PBXGroup;
-			children = (
-				CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */,
-			);
-			path = Cells;
-			sourceTree = "<group>";
-		};
-        F4BA26F32B45597600975CC2 /* MakeProfile */ = {
-			isa = PBXGroup;
-			children = (
-				F485D4902B47DDBE007317F4 /* ViewControllers */,
-			);
-			path = MakeProfile;
-			sourceTree = "<group>";
-		};
 		F485D4902B47DDBE007317F4 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
 				F4BA26F42B455A7300975CC2 /* MakeProfileViewController.swift */,
 			);
 			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		F4BA26F32B45597600975CC2 /* MakeProfile */ = {
+			isa = PBXGroup;
+			children = (
+				F485D4902B47DDBE007317F4 /* ViewControllers */,
+			);
+			path = MakeProfile;
 			sourceTree = "<group>";
 		};
 		F4BA26F82B47197100975CC2 /* Utils */ = {
@@ -625,6 +643,7 @@
 		F4F5219A2B3467FD000E6E1E /* Scene */ = {
 			isa = PBXGroup;
 			children = (
+				F430A9812B4AAE4D00D482C4 /* CompleteProfile */,
 				F4BEB4C72B482FBB0074B1B2 /* UserTestResult */,
 				9457F0492B485169009ACF25 /* StartTravel */,
 				CA8CD6982B47F57100CFDFBF /* ToDo */,
@@ -827,6 +846,7 @@
 				CA8CD6A82B483FD000CFDFBF /* DoubleButtonView.swift in Sources */,
 				946190A62B47FAB300A38A42 /* JoiningSuccessViewController.swift in Sources */,
 				CA8CD68D2B46B90000CFDFBF /* TripFriendsCollectionViewCell.swift in Sources */,
+				F430A9832B4AAEA900D482C4 /* CompleteProfileViewController.swift in Sources */,
 				9457F0552B485A68009ACF25 /* TravelTestCollectionViewCell.swift in Sources */,
 				CA8CD6852B46B7C100CFDFBF /* OurToDoHeaderView.swift in Sources */,
 				F4BA26F22B42D07000975CC2 /* PersonalInfoWebViewController.swift in Sources */,

--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		CA8CD6A42B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */; };
 		CA8CD6A82B483FD000CFDFBF /* DoubleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD6A72B483FD000CFDFBF /* DoubleButtonView.swift */; };
 		F430A9832B4AAEA900D482C4 /* CompleteProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */; };
+		F430A98A2B4AD24800D482C4 /* UserTypeTestResultAppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F430A9892B4AD24700D482C4 /* UserTypeTestResultAppData.swift */; };
 		F484A3852B3EBC2A00197E3C /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F484A3842B3EBC2A00197E3C /* UIColor+.swift */; };
 		F485D4892B47CB8B007317F4 /* UserTestSplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F485D4882B47CB8B007317F4 /* UserTestSplashViewController.swift */; };
 		F485D48D2B47CF58007317F4 /* UserTestQuestionStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = F485D48C2B47CF58007317F4 /* UserTestQuestionStruct.swift */; };
@@ -138,6 +139,7 @@
 		CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoManagerCollectionViewCell.swift; sourceTree = "<group>"; };
 		CA8CD6A72B483FD000CFDFBF /* DoubleButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleButtonView.swift; sourceTree = "<group>"; };
 		F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteProfileViewController.swift; sourceTree = "<group>"; };
+		F430A9892B4AD24700D482C4 /* UserTypeTestResultAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTypeTestResultAppData.swift; sourceTree = "<group>"; };
 		F484A3842B3EBC2A00197E3C /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		F485D4882B47CB8B007317F4 /* UserTestSplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTestSplashViewController.swift; sourceTree = "<group>"; };
 		F485D48C2B47CF58007317F4 /* UserTestQuestionStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTestQuestionStruct.swift; sourceTree = "<group>"; };
@@ -382,6 +384,14 @@
 			path = ViewControllers;
 			sourceTree = "<group>";
 		};
+		F430A9882B4ACFFE00D482C4 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				F430A9892B4AD24700D482C4 /* UserTypeTestResultAppData.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		F485D4872B47CB43007317F4 /* UserTest */ = {
 			isa = PBXGroup;
 			children = (
@@ -435,6 +445,7 @@
 		F4BEB4C72B482FBB0074B1B2 /* UserTestResult */ = {
 			isa = PBXGroup;
 			children = (
+				F430A9882B4ACFFE00D482C4 /* Models */,
 				F4BEB4CB2B4833B50074B1B2 /* Views */,
 				F4BEB4C82B482FCC0074B1B2 /* ViewControllers */,
 			);
@@ -807,6 +818,7 @@
 				CA8CD68F2B46B96E00CFDFBF /* OurToDoData.swift in Sources */,
 				F4C5E7702B4286EA0008735F /* UIImage+.swift in Sources */,
 				F4C5E7842B42A6830008735F /* UILabel+.swift in Sources */,
+				F430A98A2B4AD24800D482C4 /* UserTypeTestResultAppData.swift in Sources */,
 				9457F04C2B4853AC009ACF25 /* TravelTestViewController.swift in Sources */,
 				CA8CD6912B46B9A100CFDFBF /* FriendProfileData.swift in Sources */,
 				F4BEB4CF2B4838B60074B1B2 /* TestResultTicketView.swift in Sources */,

--- a/Going-iOS/Application/SceneDelegate.swift
+++ b/Going-iOS/Application/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 2.
         self.window = UIWindow(windowScene: windowScene)
         // 3.
-        let navigationController = UINavigationController(rootViewController: OurToDoViewController())
+        let navigationController = UINavigationController(rootViewController: CompleteProfileViewController())
         self.window?.rootViewController = navigationController
         // 4.
         self.window?.makeKeyAndVisible()

--- a/Going-iOS/Scene/CompleteProfile/ViewControllers/CompleteProfileViewController.swift
+++ b/Going-iOS/Scene/CompleteProfile/ViewControllers/CompleteProfileViewController.swift
@@ -1,0 +1,107 @@
+//
+//  CompleteProfileViewController.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/7/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class CompleteProfileViewController: UIViewController {
+    
+    private let completeProfileScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.isScrollEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+    
+    private let contentView = UIView()
+    
+    private let userProfileBackgroundView = UIView()
+    
+    private let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.image = UIImage(systemName: "pencil")
+        return imageView
+    }()
+    
+    private let userNameLabel = DOOLabel(font: .pretendard(.head2), color: .gray600, text: "곽두릅")
+    private let userDescLabel = DOOLabel(font: .pretendard(.detail1_regular), color: .gray300, text: "곽곽곽곽곽")
+    
+    private let userTypeTestResultView = TestResultView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setHierarchy()
+        setLayout()
+        setStyle()
+
+    }
+}
+
+private extension CompleteProfileViewController {
+    
+    func setHierarchy() {
+        view.addSubview(completeProfileScrollView)
+        completeProfileScrollView.addSubviews(contentView)
+        contentView.addSubviews(userProfileBackgroundView, userTypeTestResultView)
+        userProfileBackgroundView.addSubviews(profileImageView, userNameLabel, userDescLabel)
+    }
+    
+    func setLayout() {
+        
+        completeProfileScrollView.snp.makeConstraints {
+            $0.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(completeProfileScrollView.frameLayoutGuide)
+            $0.height.greaterThanOrEqualTo(view.snp.height).priority(.low)
+        }
+        
+        userProfileBackgroundView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(247))
+            
+        }
+        
+        profileImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(40)
+            $0.leading.trailing.equalToSuperview().inset(132)
+            $0.height.equalTo(ScreenUtils.getHeight(110))
+        }
+        
+        userNameLabel.snp.makeConstraints {
+            $0.top.equalTo(profileImageView.snp.bottom).offset(16)
+            $0.centerX.equalTo(profileImageView)
+        }
+        
+        userDescLabel.snp.makeConstraints {
+            $0.top.equalTo(userNameLabel.snp.bottom).offset(4)
+            $0.centerX.equalTo(userNameLabel)
+        }
+        
+        userTypeTestResultView.snp.makeConstraints {
+            $0.top.equalTo(userProfileBackgroundView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(contentView.snp.bottom)
+        }
+    }
+    
+    func setStyle() {
+        userProfileBackgroundView.backgroundColor = .gray50
+        contentView.backgroundColor = .gray50
+        profileImageView.backgroundColor = .gray200
+        view.backgroundColor = .white000
+        
+    }
+
+}

--- a/Going-iOS/Scene/UserTestResult/Models/UserTypeTestResultAppData.swift
+++ b/Going-iOS/Scene/UserTestResult/Models/UserTypeTestResultAppData.swift
@@ -1,0 +1,53 @@
+////
+////  UserTypeTestResultAppData.swift
+////  Going-iOS
+////
+////  Created by 곽성준 on 1/7/24.
+////
+//
+//import Foundation
+//
+//struct UserTypeTestResultAppData {
+//    let userType: String
+//    let userTypeDesc: String
+//    let userTypeTag: [UserTypeTags]
+//    let likePoint: [UserTypePoint]
+//    let warningPoint: [UserTypePoint]
+//    let goodPoint: [UserTypePoint]
+//}
+//
+//struct UserTypeTags {
+//    let firstTag: String
+//    let secondTag: String
+//    let thirdTag: String
+//}
+//
+//struct UserTypePoint {
+//    let firstPoint: String
+//    let secondPoint: String
+//    let thirdPoint: String
+//}
+//
+//extension UserTypeTestResultAppData {
+//    static func dummy() -> [UserTypeTestResultAppData] {
+//        return [
+//            .init(userType: "배려심 많은 인간 플래너", userTypeDesc: "꼼꼼하고 세심하게 여행을 준비하는 친구", userTypeTag: [UserTypeTags(firstTag: "친구중심", secondTag: "꼼꼼함", thirdTag: "세심함")], likePoint: [UserTypePoint(firstPoint: "같이 가는 친구들을 잘 챙기고 배려해요", secondPoint: "친구들의 의견을 잘 반영해 만족할 수 있는 일정을 계획해요", thirdPoint: "꼼꼼하고 부지런해 맡은 일에서 실수가 적어요")], warningPoint: [UserTypePoint(firstPoint: "완벽주의 성향이 강해 계획이 틀어졌을 때 예민해질 수 있어요", secondPoint: "친구들 간 갈등의 조짐이 보이면 많은 스트레스를 받는 편이에요", thirdPoint: "예기치 않은 상황에서 크게 당황하기도 해요")], goodPoint: [UserTypePoint(firstPoint: "", secondPoint: <#T##String#>, thirdPoint: <#T##String#>)]),
+//            
+//                .init(userType: "하고 싶은 것이 많은 예스맨", userTypeDesc: "여행 일정에 대한 불만이 낮은 친구", userTypeTag: [UserTypeTags(firstTag: "실용적", secondTag: "긍정적", thirdTag: "개방적")], likePoint: [UserTypePoint(firstPoint: "전반적으로 일정을 계획하고 수행하는 것에 대한 예민도가 낮아요", secondPoint: "활동적인 경험에 관심이 많아 적극적으로 탐색해요", thirdPoint: "여행에서 문제가 생겼을 때 빠르고 효과적인 방안을 마련하곤 해요")], warningPoint:
+//                        [UserTypePoint(firstPoint: "우유부단해 귀가 얇고 결정을 잘 내리지 못하는 편이에요", secondPoint: "하고 싶은 게 있어도 잘 말하지 않아 다른 사람들을 답답하게 하기도 해요", thirdPoint: "약간의 귀차니즘이 있어 중간중간 맡은 일을 잘 하고 있는지 확인 필요해요")], goodPoint: <#T##[UserTypePoint]#>),
+//            
+//                .init(userType: "꼼꼼한 인간 여행 챗지피티", userTypeDesc: "여행의 A부터 Z까지 구조화하고 관리하는 친구", userTypeTag: [UserTypeTags(firstTag: "원칙주의", secondTag: "효율성", thirdTag: "기록형")], likePoint: [UserTypePoint(firstPoint: "역할이 주어졌을 때 완벽하게 해내요", secondPoint: "효율성을 중요시해 지출을 꼼꼼하게 관리해요", thirdPoint: "여행지의 역사, 날씨, 최근 이슈 등까지 세세하고 찾아보고 알려줘요")], warningPoint: [UserTypePoint(firstPoint: "신중하지 못한 행동, 시간 약속을 지키지 못하는 것 등을 싫어해요", secondPoint: "여행 일정에 차질이 생기면 스트레스를 받곤 해요", thirdPoint: "인내심이 있지만 참다가 터질 수 있어요")], goodPoint: <#T##[UserTypePoint]#>),
+//            
+//                .init(userType: "하고 싶은 것이 명확한 오케이맨", userTypeDesc: "하고 싶은 것 외에는 너그러운 친구", userTypeTag: [UserTypeTags(firstTag: "개인우선", secondTag: "자유로움", thirdTag: "활동중심")], likePoint: [UserTypePoint(firstPoint: "하고 싶은 것만 할 수 있다면 전반적인 여행 일정에서의 포용성이 높아요", secondPoint: "활동 중심의 여행을 선호해 다양한 경험을 함께할 수 있어요", thirdPoint: "예기치 못한 일에도 무난하게 대안을 제시할 수 있어요")], warningPoint: [UserTypePoint(firstPoint: "하고 싶지 않은 일을 강요받으면 여행 자체에 대한 만족도가 크게 떨어져요", secondPoint: "앞장서서 상황을 해결하는 것을 좋아하지 않음", thirdPoint: "혼자만의 시간이 보장되어야 해요")], goodPoint: <#T##[UserTypePoint]#>),
+//            
+//                .init(userType: "친구들을 잘 챙기는 반장", userTypeDesc: "모두가 즐거운 여행이 되도록 책임지는 친구", userTypeTag: [UserTypeTags(firstTag: "리더십", secondTag: "배려심", thirdTag: "친절함")], likePoint: [UserTypePoint(firstPoint: "여행을 꼼꼼하게 준비하는 편으로 없는 물건, 생각하지 못한 일정이 없어요", secondPoint: "친구에 대한 이해도가 높아 기분을 잘 파악하거나 할일을 적절하게 분배해요", thirdPoint: "친구들을 위해 잘 나서는 타입이에요")], warningPoint: [UserTypePoint(firstPoint: "일정이 원하는대로 되지 않거나 친구들이 다투면 엄청난 스트레스를 받아요", secondPoint: "주도적으로 한 일이 상대방에게 낮은 평가를 받는 경우 큰 상처를 받아요", thirdPoint: "싫은 소리를 하는 것을 두려워 해 불만이 있어도 마음에 쌓아두곤 해요")], goodPoint: <#T##[UserTypePoint]#>),
+//            
+//                .init(userType: "여행을 100배 즐기는 치어리더", userTypeDesc: "친구들과 함께하는 것에 큰 즐거움을 느끼는 친구", userTypeTag: [UserTypeTags(firstTag: "낙천적", secondTag: "순간기록", thirdTag: "호기심")], likePoint: [UserTypePoint(firstPoint: "사진, 동영상 등으로 여행에서 기록을 많이 남겨요", secondPoint: "함께하는 새로운 경험 자체가 중요하기 때문에 여행의 불만도가 낮아요", thirdPoint: "항상 친구들에게 따뜻하고 응원하는 듯한 태도를 가지고 있어요")], warningPoint: [UserTypePoint(firstPoint: "즉흥적으로 하고 싶은 것이 생겨 기존 계획에 어긋나는 제안을 하곤 해요", secondPoint: "계획을 세우는 행위 자체를 싫어해 중장기 계획을 세우는 데에는 취약해요", thirdPoint: "덜렁거려 평소에 잘 다쳐요")], goodPoint: <#T##[UserTypePoint]#>),
+//            
+//                .init(userType: "모든 것을 계획하는 인간 총대", userTypeDesc: "후회 없는 여행이 되도록 철두철미하게 계획하는 친구", userTypeTag: [UserTypeTags(firstTag: "주도적", secondTag: "똑부러짐", thirdTag: "준비성")], likePoint: [UserTypePoint(firstPoint: "꼼꼼한 일정 계획으로 알찬 여행을 다녀올 수 있어요", secondPoint: "효율을 추구해 나와 친구가 원하는 곳을 모두 갈 수 있게 일정을 계획해요", thirdPoint: "부당한 일을 겪는 경우, 앞장서서 항의하곤 해요")], warningPoint: [UserTypePoint(firstPoint: "개인이 하고 싶어서 짠 스케줄에 대해 방해받는 것을 싫어해요", secondPoint: "내가 하고 싶은 일을 존중하지 않으면 여행을 잘 가고 싶지 않아해요", thirdPoint: "약간은 냉철하게 이야기하는 편이기도 해요")], goodPoint: <#T##[UserTypePoint]#>),
+//            
+//                .init(userType: "머릿 속이 상상으로 가득한 작가", userTypeDesc: "궁금한 것도 하고 싶은 것도 많은 호기심 Max 친구", userTypeTag: [UserTypeTags(firstTag: "상상력", secondTag: "호기심", thirdTag: "소심함")], likePoint: [UserTypePoint(firstPoint: "호기심과 도전 정신이 강해 친구들을 새로운 경험으로 이끌 수 있어요", secondPoint: "함께하는 친구들에게 피해를 주거나 민폐가 되지 않기 위해 노력해요", thirdPoint: "유연한 상황 판단과 융툥성 있는 대처로 여행 과정에서의 이슈를 해결해요")], warningPoint: [UserTypePoint(firstPoint: "하고 싶은 일과 하고 싶지 않은 일이 명확해요", secondPoint: "하고 싶은 활동이 함께 여행하는 친구들에게는 매력적이지 않을 수 있어요", thirdPoint: "말하지는 않지만 속으로 수많은 것들을 생각 중일 수 있어요")], goodPoint: <#T##[UserTypePoint]#>)
+//            
+//        ]
+//    }
+//}

--- a/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
+++ b/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
@@ -55,7 +55,6 @@ final class UserTestResultViewController: UIViewController {
         setStyle()
         setHierarchy()
         setLayout()
-        resultView.backgroundColor = .white
         
     }
     
@@ -73,6 +72,7 @@ private extension UserTestResultViewController {
     func setStyle() {
         contentView.backgroundColor = .blue
         view.backgroundColor = .white000
+        resultView.backgroundColor = .white
     }
     
     func setHierarchy() {

--- a/Going-iOS/Scene/UserTestResult/Views/TestResultView.swift
+++ b/Going-iOS/Scene/UserTestResult/Views/TestResultView.swift
@@ -84,12 +84,12 @@ extension TestResultView {
         }
         
         subTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(userTypeLabel.snp.bottom)
+            $0.top.equalTo(userTypeLabel.snp.bottom).offset(1)
             $0.centerX.equalToSuperview()
         }
         
         tagStackView.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(8)
+            $0.top.equalTo(subTitleLabel.snp.bottom).offset(12)
             $0.centerX.equalToSuperview()
         }
         
@@ -109,5 +109,6 @@ extension TestResultView {
     
     func setStyle() {
         self.roundCorners(cornerRadius: 8, maskedCorners: [.layerMaxXMinYCorner, .layerMinXMinYCorner])
+        self.backgroundColor = .white000
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- #32

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 프로필완성뷰 UI 구현
- 성향테스트결과 데이터더미 생성

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 성향테스트결과 데이터 더미는 현재 기획단에서 다 나오지 않아서, 나오는 대로 추가한 후에 테스트해보겠습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 15 Pro - 2024-01-07 at 23 14 57](https://github.com/Team-Going/Going-iOS/assets/70939232/bffd1ead-14ee-4033-acd2-4956788660df)|



|기능|스크린샷|
|:--:|:--:|
|아이폰13mini|![Simulator Screen Recording - iPhone 13 mini - 2024-01-07 at 23 12 14](https://github.com/Team-Going/Going-iOS/assets/70939232/c624a3f1-6714-49de-a0c0-5907ced10331)|


## 📟 관련 이슈
- Resolved: #32
