### PR TITLE
[FEAT] 이미지 저장 로직 및 성향테스트뷰 버튼 로직 구현(#43)

### DIFF
--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		CADA02592B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA02582B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift */; };
 		F430A9832B4AAEA900D482C4 /* CompleteProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */; };
 		F430A98A2B4AD24800D482C4 /* UserTypeTestResultAppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F430A9892B4AD24700D482C4 /* UserTypeTestResultAppData.swift */; };
+		F44460FD2B4D098B00674D74 /* CheckPhotoAccessProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44460FC2B4D098B00674D74 /* CheckPhotoAccessProtocol.swift */; };
 		F484A3852B3EBC2A00197E3C /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F484A3842B3EBC2A00197E3C /* UIColor+.swift */; };
 		F485D4892B47CB8B007317F4 /* UserTestSplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F485D4882B47CB8B007317F4 /* UserTestSplashViewController.swift */; };
 		F485D48D2B47CF58007317F4 /* UserTestQuestionStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = F485D48C2B47CF58007317F4 /* UserTestQuestionStruct.swift */; };
@@ -162,6 +163,7 @@
 		CADA02582B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyToDoCollectionViewCell.swift; sourceTree = "<group>"; };
 		F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteProfileViewController.swift; sourceTree = "<group>"; };
 		F430A9892B4AD24700D482C4 /* UserTypeTestResultAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTypeTestResultAppData.swift; sourceTree = "<group>"; };
+		F44460FC2B4D098B00674D74 /* CheckPhotoAccessProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPhotoAccessProtocol.swift; sourceTree = "<group>"; };
 		F484A3842B3EBC2A00197E3C /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		F485D4882B47CB8B007317F4 /* UserTestSplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTestSplashViewController.swift; sourceTree = "<group>"; };
 		F485D48C2B47CF58007317F4 /* UserTestQuestionStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTestQuestionStruct.swift; sourceTree = "<group>"; };
@@ -425,22 +427,6 @@
 			path = ViewControllers;
 			sourceTree = "<group>";
 		};
-		F430A9812B4AAE4D00D482C4 /* CompleteProfile */ = {
-			isa = PBXGroup;
-			children = (
-				F430A9842B4ABFC200D482C4 /* ViewControllers */,
-			);
-			path = CompleteProfile;
-			sourceTree = "<group>";
-		};
-		F430A9842B4ABFC200D482C4 /* ViewControllers */ = {
-			isa = PBXGroup;
-			children = (
-				F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */,
-			);
-			path = ViewControllers;
-			sourceTree = "<group>";
-		};
 		CA8CD6982B47F57100CFDFBF /* ToDo */ = {
 			isa = PBXGroup;
 			children = (
@@ -518,6 +504,30 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		F430A9812B4AAE4D00D482C4 /* CompleteProfile */ = {
+			isa = PBXGroup;
+			children = (
+				F430A9842B4ABFC200D482C4 /* ViewControllers */,
+			);
+			path = CompleteProfile;
+			sourceTree = "<group>";
+		};
+		F430A9842B4ABFC200D482C4 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				F430A9822B4AAEA900D482C4 /* CompleteProfileViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		F430A9882B4ACFFE00D482C4 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				F430A9892B4AD24700D482C4 /* UserTypeTestResultAppData.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		F485D4872B47CB43007317F4 /* UserTest */ = {
 			isa = PBXGroup;
 			children = (
@@ -544,20 +554,20 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		F4BA26F32B45597600975CC2 /* MakeProfile */ = {
-			isa = PBXGroup;
-			children = (
-				F485D4902B47DDBE007317F4 /* ViewControllers */,
-			);
-			path = MakeProfile;
-			sourceTree = "<group>";
-		};
 		F485D4902B47DDBE007317F4 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
 				F4BA26F42B455A7300975CC2 /* MakeProfileViewController.swift */,
 			);
 			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		F4BA26F32B45597600975CC2 /* MakeProfile */ = {
+			isa = PBXGroup;
+			children = (
+				F485D4902B47DDBE007317F4 /* ViewControllers */,
+			);
+			path = MakeProfile;
 			sourceTree = "<group>";
 		};
 		F4BA26F82B47197100975CC2 /* Utils */ = {
@@ -593,14 +603,6 @@
 				F4BEB4CE2B4838B60074B1B2 /* TestResultTicketView.swift */,
 			);
 			path = Views;
-			sourceTree = "<group>";
-		};
-		F430A9882B4ACFFE00D482C4 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				F430A9892B4AD24700D482C4 /* UserTypeTestResultAppData.swift */,
-			);
-			path = Models;
 			sourceTree = "<group>";
 		};
 		F4F521682B3440D7000E6E1E = {
@@ -698,6 +700,7 @@
 		F4F5218F2B34640F000E6E1E /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
+				F44460FC2B4D098B00674D74 /* CheckPhotoAccessProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -986,6 +989,7 @@
 				F4BEB4D12B4A79AB0074B1B2 /* UIButton+.swift in Sources */,
 				94442EBA2B4ABC2300FDBB26 /* DashBoardCollectionViewCell.swift in Sources */,
 				94C7DDB32B4C754300541567 /* SettingsViewController.swift in Sources */,
+				F44460FD2B4D098B00674D74 /* CheckPhotoAccessProtocol.swift in Sources */,
 				F485D4892B47CB8B007317F4 /* UserTestSplashViewController.swift in Sources */,
 				94442EBD2B4AC6F500FDBB26 /* TravelInfoStruct.swift in Sources */,
 				9431CDC72B47F0C500CB452E /* NavigationView.swift in Sources */,

--- a/Going-iOS/Application/AppDelegate.swift
+++ b/Going-iOS/Application/AppDelegate.swift
@@ -63,6 +63,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationDidEnterBackground(_ application: UIApplication) {
+        
     }
     
     //    func photoLibraryDidChange(_ changeInstance: PHChange) {

--- a/Going-iOS/Application/AppDelegate.swift
+++ b/Going-iOS/Application/AppDelegate.swift
@@ -13,10 +13,13 @@ import Photos
 
 //PHPhotoLibraryChangeObserver
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, CheckPhotoAccessProtocol {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        
+        //앱이 처음 실행될 때, Access체크를 해서 UserDefault값을 변경해준다. 재실행해도 상관x
+        checkAccess()
         
         let kakaoNativeAppKey = Config.kakaoNativeAppKey
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
@@ -41,9 +44,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 break
             }
         }
-        
-//        PHPhotoLibrary.shared().register(self)
-        
         return true
     }
     
@@ -61,24 +61,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-    
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        
-    }
-    
-    //    func photoLibraryDidChange(_ changeInstance: PHChange) {
-    //           // 사진 라이브러리 변경 사항 감지
-    //           // 권한 변경 여부 확인 및 필요한 작업 수행
-    //           if let details = changeInstance.changeDetails(for: PHAssetCollection.fetchTopLevelUserCollections(with: nil)) {
-    //               // 권한 변경 여부 확인
-    //               if details.hasIncrementalChanges {
-    //                   // 변경이 감지되었을 때 필요한 작업 수행
-    //                   print("Photo library permissions might have changed.")
-    //               }
-    //           }
-    //       }
-    
-    
-    
+
 }
 

--- a/Going-iOS/Application/SceneDelegate.swift
+++ b/Going-iOS/Application/SceneDelegate.swift
@@ -13,7 +13,7 @@ import Photos
 
 
 
-class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+class SceneDelegate: UIResponder, UIWindowSceneDelegate, CheckPhotoAccessProtocol {
     
     var window: UIWindow?
     
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 2.
         self.window = UIWindow(windowScene: windowScene)
         // 3.
-        let navigationController = UINavigationController(rootViewController: SplashViewController())
+        let navigationController = UINavigationController(rootViewController: UserTestViewController())
         self.window?.rootViewController = navigationController
         // 4.
         self.window?.makeKeyAndVisible()
@@ -42,51 +42,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: "여기에 credential.user 넣기") { (credentialState, error) in
             switch credentialState {
-                case .authorized:
-                   print("authorized")
-                   // The Apple ID credential is valid.
-//                   DispatchQueue.main.async {
-//                     //authorized된 상태이므로 바로 로그인 완료 화면으로 이동
-//                     self.window?.rootViewController = ViewController()
-//                   }
-                case .revoked:
-                   print("revoked")
-                case .notFound:
-                   // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
-                   print("notFound")
-                default:
-                    break
+            case .authorized:
+                print("authorized")
+                // The Apple ID credential is valid.
+                //                   DispatchQueue.main.async {
+                //                     //authorized된 상태이므로 바로 로그인 완료 화면으로 이동
+                //                     self.window?.rootViewController = ViewController()
+                //                   }
+            case .revoked:
+                print("revoked")
+            case .notFound:
+                // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
+                print("notFound")
+            default:
+                break
             }
         }
+        checkAccess()
     }
-    
-    // 사진 라이브러리 권한 확인 및 처리
-//       private func checkPhotoLibraryPermission() {
-//           let status = PHPhotoLibrary.authorizationStatus()
-//
-//           switch status {
-//           case .authorized:
-//               // 이미 권한이 허용된 상태
-//               print("Photo Library access is authorized.")
-//           case .denied, .restricted:
-//               // 권한이 거부되거나 제한된 상태
-//               print("Photo Library access is denied or restricted.")
-//               // 여기에서 권한을 변경하는 액션을 수행할 수 있음
-//           case .notDetermined:
-//               // 권한이 아직 요청되지 않은 상태
-//               PHPhotoLibrary.requestAuthorization { (newStatus) in
-//                   if newStatus == .authorized {
-//                       print("Photo Library access is granted.")
-//                   } else {
-//                       print("Photo Library access is still not authorized.")
-//                       // 여기에서 권한을 변경하는 액션을 수행할 수 있음
-//                   }
-//               }
-//           case .limited:
-//               break
-//           @unknown default:
-//               break
-//           }
-//       }
-
 }

--- a/Going-iOS/Application/SceneDelegate.swift
+++ b/Going-iOS/Application/SceneDelegate.swift
@@ -13,7 +13,7 @@ import Photos
 
 
 
-class SceneDelegate: UIResponder, UIWindowSceneDelegate, CheckPhotoAccessProtocol {
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
     
@@ -24,10 +24,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, CheckPhotoAccessProtoco
         // 2.
         self.window = UIWindow(windowScene: windowScene)
         // 3.
-        let navigationController = UINavigationController(rootViewController: UserTestViewController())
+        let navigationController = UINavigationController(rootViewController: SplashViewController())
         self.window?.rootViewController = navigationController
         // 4.
         self.window?.makeKeyAndVisible()
+        
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -58,6 +59,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, CheckPhotoAccessProtoco
                 break
             }
         }
-        checkAccess()
     }
 }

--- a/Going-iOS/Global/Protocols/CheckPhotoAccessProtocol.swift
+++ b/Going-iOS/Global/Protocols/CheckPhotoAccessProtocol.swift
@@ -1,0 +1,26 @@
+//
+//  CheckPhotoAccessProtocol.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/9/24.
+//
+
+import Foundation
+import Photos
+
+protocol CheckPhotoAccessProtocol: AnyObject {
+    func checkAccess()
+}
+
+extension CheckPhotoAccessProtocol {
+    func checkAccess() {
+        switch PHPhotoLibrary.authorizationStatus(for: .addOnly) {
+        case .authorized, .limited, .restricted:
+            UserDefaults.standard.set(true, forKey: "photoPermissionKey")
+        case .notDetermined, .denied:
+            UserDefaults.standard.set(false, forKey: "photoPermissionKey")
+        @unknown default:
+            return
+        }
+    }
+}

--- a/Going-iOS/Scene/Login/ViewControllers/SplashViewController.swift
+++ b/Going-iOS/Scene/Login/ViewControllers/SplashViewController.swift
@@ -10,10 +10,6 @@ import UIKit
 import SnapKit
 
 final class SplashViewController: UIViewController {
-    
-    private enum Size {
-        static let logoHeight: CGFloat = 66 / 194
-    }
 
     private let splashLogoImageView: UIImageView = {
         let imageView = UIImageView()
@@ -32,10 +28,8 @@ final class SplashViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        performActionBasedOnPermission()
+        pushActionBasedOnPermission()
     }
-
-    
 }
 
 private extension SplashViewController {
@@ -57,7 +51,7 @@ private extension SplashViewController {
         }
     }
     
-    func performActionBasedOnPermission() {
+    func pushActionBasedOnPermission() {
         if UserDefaults.standard.bool(forKey: "photoPermissionKey") {
             // 권한이 설정된 경우의 동작
             print("설정 가능")
@@ -70,10 +64,4 @@ private extension SplashViewController {
             self.navigationController?.pushViewController(nextVC, animated: true)
         }
     }
-    
-//    @objc
-//    func userDefaultsDidChange() {
-//        let moveToUserTestResult = UserTestResultViewController()
-//        self.navigationController?.pushViewController(moveToUserTestResult, animated: true)
-//    }
 }

--- a/Going-iOS/Scene/Login/ViewControllers/SplashViewController.swift
+++ b/Going-iOS/Scene/Login/ViewControllers/SplashViewController.swift
@@ -11,9 +11,6 @@ import SnapKit
 
 final class SplashViewController: UIViewController {
     
-    let testUserDefault = UserDefaults.standard.bool(forKey: "ImageSave")
-    
-    
     private enum Size {
         static let logoHeight: CGFloat = 66 / 194
     }
@@ -34,16 +31,24 @@ final class SplashViewController: UIViewController {
 
     }
     
-    private func setStyle() {
+    override func viewDidAppear(_ animated: Bool) {
+        performActionBasedOnPermission()
+    }
+
+    
+}
+
+private extension SplashViewController {
+     func setStyle() {
         self.view.backgroundColor = .red400
     }
     
-    private func setHierarchy() {
+     func setHierarchy() {
         view.addSubview(splashLogoImageView)
         
     }
     
-    private func setLayout() {
+    func setLayout() {
         
         splashLogoImageView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
@@ -51,5 +56,24 @@ final class SplashViewController: UIViewController {
             $0.height.equalTo(ScreenUtils.getHeight(66))
         }
     }
-
+    
+    func performActionBasedOnPermission() {
+        if UserDefaults.standard.bool(forKey: "photoPermissionKey") {
+            // 권한이 설정된 경우의 동작
+            print("설정 가능")
+            let nextVC = UserTestResultViewController()
+            self.navigationController?.pushViewController(nextVC, animated: true)
+        } else {
+            // 권한이 거부된 경우의 동작
+            print("설정 불가능")
+            let nextVC = LoginViewController()
+            self.navigationController?.pushViewController(nextVC, animated: true)
+        }
+    }
+    
+//    @objc
+//    func userDefaultsDidChange() {
+//        let moveToUserTestResult = UserTestResultViewController()
+//        self.navigationController?.pushViewController(moveToUserTestResult, animated: true)
+//    }
 }

--- a/Going-iOS/Scene/UserTest/ViewControllers/UserTestViewController.swift
+++ b/Going-iOS/Scene/UserTest/ViewControllers/UserTestViewController.swift
@@ -139,10 +139,9 @@ private extension UserTestViewController {
     
     func updateNextButtonState() {
         // 선택된 버튼이 있는지 확인하고 nextButton의 활성화 여부를 결정
-        if selectedButton != nil {
-            nextButton.isEnabled = true
-        }
+        nextButton.isEnabled = selectedButton == nil ? false : true
         nextButton.backgroundColor = nextButton.isEnabled ? .gray500 : .gray50
+
         if nextButton.isEnabled {
             nextButton.setTitleColor(.white000, for: .normal)
         } else {
@@ -177,7 +176,6 @@ private extension UserTestViewController {
         }) { [self] _ in
             // fade out 애니메이션 종료 후 실행될 코드
             updateLabel()
-            
             UIView.animate(withDuration: 0.5) {
                 viewsToAnimate.forEach { $0?.alpha = 1.0 }
             }
@@ -214,28 +212,30 @@ private extension UserTestViewController {
     
     @objc
     func nextButtonTapped() {
-        
+        resetButtons()
         if index < userTestDataStruct.count - 1 {
             
             // 질문이 마지막이 아닌 경우
             testProgressView.setProgress(testProgressView.progress + 0.1111111, animated: true)
             index += 1
             setAnimation()
-            resetButtons()
             buttonIndexList.append(self.buttonIndex)
             
             // nextButton 상태 초기화
             nextButton.backgroundColor = .gray50
             nextButton.setTitleColor(.gray200, for: .normal)
+            updateNextButtonState()
             
         } else {
             // 질문이 마지막인 경우
             setAnimation()
             buttonIndexList.append(self.buttonIndex)
             handleLastQuestion()
+            
         }
         if index == 8 {
             nextButton.setTitle("제출하기", for: .normal)
+            updateNextButtonState()
         }
     }
 }

--- a/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
+++ b/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
@@ -139,32 +139,7 @@ private extension UserTestResultViewController {
     
     @objc
     func saveImageButtonTapped() {
-        
-        switch PHPhotoLibrary.authorizationStatus(for: .addOnly) {
-            
-        case .notDetermined:
-            print("not determined")
-            PHPhotoLibrary.requestAuthorization(for: .addOnly) { [weak self] status in
-                switch status {
-                case .authorized, .limited:
-                    print("권한설정됐다는 토스트? 띄우면 좋을듯")
-                case .denied:
-                    DispatchQueue.main.async {
-                        self?.showPermissionAlert()
-                    }
-                default:
-                    print("그 밖의 권한이 부여 되었습니다.")
-                }
-            }
-        case .restricted, .limited, .authorized:
-            saveImage()
-        case .denied:
-            DispatchQueue.main.async {
-                self.showPermissionAlert()
-            }
-        @unknown default:
-            print("unKnown")
-        }
+        checkAccess()
     }
     
     func saveImage() {
@@ -191,6 +166,35 @@ private extension UserTestResultViewController {
             
             self.present(alert, animated: true)
             
+        }
+    }
+}
+
+extension UserTestResultViewController: CheckPhotoAccessProtocol {
+    func checkAccess() {
+        switch PHPhotoLibrary.authorizationStatus(for: .addOnly) {
+            
+        case .notDetermined, .denied:
+            UserDefaults.standard.set(false, forKey: "photoPermissionKey")
+            PHPhotoLibrary.requestAuthorization(for: .addOnly) { [weak self] status in
+                switch status {
+                case .authorized, .limited:
+                    UserDefaults.standard.set(true, forKey: "photoPermissionKey")
+                    print("권한설정됐다는 토스트? 띄우면 좋을듯")
+                case .denied:
+                    DispatchQueue.main.async {
+                        self?.showPermissionAlert()
+                    }
+                default:
+                    print("그 밖의 권한이 부여 되었습니다.")
+                }
+                
+            }
+        case .restricted, .limited, .authorized:
+            saveImage()
+            UserDefaults.standard.set(true, forKey: "photoPermissionKey")
+        @unknown default:
+            print("unKnown")
         }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- /#43

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 이미지 저장 권한 설정 분기처리 로직 구현
- 성향테스트뷰 버튼 로직 구현
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 이미지 저장 권한 체크 프로토콜
- 우선 유저의 이미지 저장 권한을 UserDefault에 넣어 관리하기로 하였습니다.
- AppDelegate와 UserTestResultVC에서 사용하는 메소드의 의미가 똑같기 때문에 프로토콜로 빼두었습니다. 또한 추후에 추가될 프로필뷰에서 저장버튼에서도 사용될 예정입니다.

또한 extension을 사용해서 메서드의 내부를 기본적으로 구현해두었습니다.
```swift
protocol CheckPhotoAccessProtocol: AnyObject {
    func checkAccess()
}

extension CheckPhotoAccessProtocol {
    func checkAccess() {
        switch PHPhotoLibrary.authorizationStatus(for: .addOnly) {
        case .authorized, .limited, .restricted:
            UserDefaults.standard.set(true, forKey: "photoPermissionKey")
        case .notDetermined, .denied:
            UserDefaults.standard.set(false, forKey: "photoPermissionKey")
        @unknown default:
            return
        }
    }
}
```

AppDelegate에서는 위 프로토콜을 채택받고, 메서드만 실행시켜주면 됩니다.
```swift
class AppDelegate: UIResponder, UIApplicationDelegate, CheckPhotoAccessProtocol {
    
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
        // Override point for customization after application launch.
        
        //앱이 처음 실행될 때, Access체크를 해서 UserDefault값을 변경해준다. 재실행해도 상관x
        checkAccess()
```

UserTestResultVC에서는 프로토콜을 채택받고, 내용이 약간 다르기 때문에 따로 메서드를 구현해주었습니다.
```swift
extension UserTestResultViewController: CheckPhotoAccessProtocol {
    func checkAccess() {
        switch PHPhotoLibrary.authorizationStatus(for: .addOnly) {
            
        case .notDetermined, .denied:
            UserDefaults.standard.set(false, forKey: "photoPermissionKey")
            PHPhotoLibrary.requestAuthorization(for: .addOnly) { [weak self] status in
                switch status {
                case .authorized, .limited:
                    UserDefaults.standard.set(true, forKey: "photoPermissionKey")
                    print("권한설정됐다는 토스트? 띄우면 좋을듯")
                case .denied:
                    DispatchQueue.main.async {
                        self?.showPermissionAlert()
                    }
                default:
                    print("그 밖의 권한이 부여 되었습니다.")
                }
                
            }
        case .restricted, .limited, .authorized:
            saveImage()
            UserDefaults.standard.set(true, forKey: "photoPermissionKey")
        @unknown default:
            print("unKnown")
        }
    }
}

 @objc
    func saveImageButtonTapped() {
        checkAccess()
    }
```

### 이미지 저장 권한 체크 위치
- 고민은 권한을 변경했을 때, 앱이 재실행되므로 어디서 변경된 설정값을 호출할 지였습니다. 
선택지는 sceneDelegate, appdelegate였는데 appDelegate의 didFinishLaunchingWithOptions에서 호출해서 UserDefault값을 설정값에 따라 변경해주었습니다.
처음에는 sceneDelegate의 sceneDidBecomeActive에서 실행시켜주었는데 불필요할 때도 호출됐기 때문에 위와 같이 변경하였습니다.
```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
        // Override point for customization after application launch.
        
        //앱이 처음 실행될 때, Access체크를 해서 UserDefault값을 변경해준다. 재실행해도 상관x
        checkAccess()
```
### SplashVC에서 이미지 저장 권한에 따른 분기 처리
- 위와 같이 저장 권한을 체크해서 변경해준 후, Splash에서 UserDefault값을 통해 어디 뷰로 보낼 지 분기처리를 해두었습니다.
- 그리고 pushActionBasedOnPermission 메서드를 viewDidAppear에서 호출했습니다.
```swift
func pushActionBasedOnPermission() {
        if UserDefaults.standard.bool(forKey: "photoPermissionKey") {
            // 권한이 설정된 경우의 동작
            print("설정 가능")
            let nextVC = UserTestResultViewController()
            self.navigationController?.pushViewController(nextVC, animated: true)
        } else {
            // 권한이 거부된 경우의 동작
            print("설정 불가능")
            let nextVC = LoginViewController()
            self.navigationController?.pushViewController(nextVC, animated: true)
        }
    }
```

### 성향테스트뷰 버튼 로직 gif는 따로 올리지 않도록 하겠습니다. 
- 그저 선택지 버튼이 클릭되어있지않으면, nextButton을 막았습니다.

### 마지막으로 죄송합니다..
- 까먹고 통커밋해버렸습니다..하하..🙏


## 📸 스크린샷
- 테스트용도로 사진저장 권한이 있으면 성향테스트결과뷰로 이동하게 해두었고, 없으면 로그인VC로 이동하게 만들어두었습니다.


|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src = "" width ="250">|
![Simulator Screen Recording - iPhone 15 Pro - 2024-01-09 at 15 35 43](https://github.com/Team-Going/Going-iOS/assets/70939232/4346d6aa-aea0-4b77-9e23-3f8b475d071e)


|기능|스크린샷|
|:--:|:--:|
|아이폰13mini|![Simulator Screen Recording - iPhone 13 mini - 2024-01-09 at 15 39 52](https://github.com/Team-Going/Going-iOS/assets/70939232/95b112c5-38ae-4241-b6fc-923ee84f8c8b)|



## 📟 관련 이슈
- Resolved: #43