### PR TITLE
[FEAT] 카카오 로그인 구현(#80)

### DIFF
--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		F4F521B42B3484B4000E6E1E /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F521B32B3484B4000E6E1E /* Config.swift */; };
 		F4F521BE2B34A091000E6E1E /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F4F521BD2B34A091000E6E1E /* SnapKit */; };
 		F4FE6B802B4FCCA4009C935E /* GetProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B7F2B4FCCA4009C935E /* GetProfileDTO.swift */; };
+		F4FE6B872B504C8C009C935E /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B862B504C8C009C935E /* AuthService.swift */; };
+		F4FE6B8E2B50514F009C935E /* LoginRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B8D2B50514F009C935E /* LoginRequestDTO.swift */; };
+		F4FE6B902B5051E4009C935E /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B8F2B5051E4009C935E /* LoginResponseDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -250,6 +253,9 @@
 		F4F521952B346576000E6E1E /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 		F4F521B32B3484B4000E6E1E /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		F4FE6B7F2B4FCCA4009C935E /* GetProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProfileDTO.swift; sourceTree = "<group>"; };
+		F4FE6B862B504C8C009C935E /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		F4FE6B8D2B50514F009C935E /* LoginRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequestDTO.swift; sourceTree = "<group>"; };
+		F4FE6B8F2B5051E4009C935E /* LoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDTO.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -661,6 +667,8 @@
 		F44D986A2B4ECABE00341893 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
+				F4FE6B8C2B505125009C935E /* Request */,
+				F4FE6B8B2B50511C009C935E /* Response */,
 				F44D986B2B4ECACC00341893 /* Token.swift */,
 			);
 			path = Auth;
@@ -925,6 +933,7 @@
 			isa = PBXGroup;
 			children = (
 				F41F5D782B4EF431000D0472 /* ToDoService.swift */,
+				F4FE6B862B504C8C009C935E /* AuthService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1028,6 +1037,22 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		F4FE6B8B2B50511C009C935E /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				F4FE6B8F2B5051E4009C935E /* LoginResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		F4FE6B8C2B505125009C935E /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				F4FE6B8D2B50514F009C935E /* LoginRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1128,6 +1153,7 @@
 				CA8CD6812B46B70700CFDFBF /* TripHeaderView.swift in Sources */,
 				F44D98602B4EB70500341893 /* HTTPHeaderField.swift in Sources */,
 				F44D985C2B4EB5F600341893 /* NameSpace.swift in Sources */,
+				F4FE6B902B5051E4009C935E /* LoginResponseDTO.swift in Sources */,
 				CA8CD68F2B46B96E00CFDFBF /* OurToDoData.swift in Sources */,
 				F4C5E7702B4286EA0008735F /* UIImage+.swift in Sources */,
 				F44D98642B4EB79700341893 /* Serviceable.swift in Sources */,
@@ -1190,6 +1216,7 @@
 				94761A072B4DD18B00D7C589 /* LogOutPopUpViewController.swift in Sources */,
 				F4BA26F52B455A7300975CC2 /* MakeProfileViewController.swift in Sources */,
 				F4C5E7882B42AC010008735F /* StringLiterals.swift in Sources */,
+				F4FE6B8E2B50514F009C935E /* LoginRequestDTO.swift in Sources */,
 				CADA02592B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift in Sources */,
 				F44D98682B4EC71900341893 /* ViewControllerServiceable.swift in Sources */,
 				F44D986C2B4ECACC00341893 /* Token.swift in Sources */,
@@ -1214,6 +1241,7 @@
 				F44461092B4D8EB300674D74 /* PopUpDimmedViewController.swift in Sources */,
 				F4BA26FC2B471A1800975CC2 /* Constant.swift in Sources */,
 				F485D48F2B47CF9B007317F4 /* UserTestViewController.swift in Sources */,
+				F4FE6B872B504C8C009C935E /* AuthService.swift in Sources */,
 				F44461062B4D7F1100674D74 /* UIWindow+.swift in Sources */,
 				F49B35312B35EC760080A19F /* Codable+.swift in Sources */,
 				9457F0522B4859BB009ACF25 /* UITableViewCell+.swift in Sources */,

--- a/Going-iOS/Application/SceneDelegate.swift
+++ b/Going-iOS/Application/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 2.
         self.window = UIWindow(windowScene: windowScene)
         // 3.
-        let navigationController = UINavigationController(rootViewController: UserTestViewController())
+        let navigationController = UINavigationController(rootViewController: LoginViewController())
         self.window?.rootViewController = navigationController
         navigationController.isNavigationBarHidden = true
         // 4.

--- a/Going-iOS/Global/Literals/ImageLiterals.swift
+++ b/Going-iOS/Global/Literals/ImageLiterals.swift
@@ -97,6 +97,7 @@ enum ImageLiterals {
         static var tabbarOurToDoSelected: UIImage { .load(named: "tabbar_ourtodo_selected") }
         static var tabbarOurToDoUnselected: UIImage { .load(named: "tabbar_ourtodo_unselected") }
         static var tabbarMyToDoSelected: UIImage { .load(named: "tabbar_mytodo_selected") }
+    }
     enum UserTestTypeCharacter {
         static var aeiCharac: UIImage { .load(named: "img_testresult_aei")}
         static var aepCharac: UIImage { .load(named: "img_testresult_aep")}

--- a/Going-iOS/Global/Protocols/Serviceable.swift
+++ b/Going-iOS/Global/Protocols/Serviceable.swift
@@ -13,12 +13,12 @@ protocol Serviceable {
     /// - Parameters:
     ///   - data: Data타입의 통신 결과
     ///   - decodeType: Data타입의 통신결과를 해당 타입으로 decode
-    func dataDecodeAndhandleErrorCode<T: Response>(data: Data, decodeType: T.Type) throws -> T?
+    func dataDecodeAndhandleErrorCode<T: Codable>(data: Data, decodeType: T.Type) throws -> T?
 }
 
 extension Serviceable {
     @discardableResult
-    func dataDecodeAndhandleErrorCode<T: Response>(data: Data, decodeType: T.Type) throws -> T? {
+    func dataDecodeAndhandleErrorCode<T: Codable>(data: Data, decodeType: T.Type) throws -> T? {
 
         guard let model = try? JSONDecoder().decode(BaseResponse<T>.self, from: data) else {
             throw NetworkError.jsonDecodingError
@@ -27,12 +27,9 @@ extension Serviceable {
         print("✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨")
         dump(model)
         
-        let statucCode = model.status
-        let code = model.code
+        print(model.message)
+        print(model.status)
         
-        if code == "e500" {
-            throw NetworkError.serverError
-        }
 
 //        let statusCode = model.code
 //        guard !NetworkErrorCode.clientErrorCode.contains(statusCode) else {

--- a/Going-iOS/Global/Settings/Info.plist
+++ b/Going-iOS/Global/Settings/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
 	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>
@@ -34,7 +36,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<false/>
+		<true/>
 	</dict>
 	<key>UIAppFonts</key>
 	<array>

--- a/Going-iOS/Global/UserDefault/UserDefaultToken.swift
+++ b/Going-iOS/Global/UserDefault/UserDefaultToken.swift
@@ -6,4 +6,8 @@
 //
 
 import Foundation
-// UserDefault에 우리가 저장하는 구조체
+
+enum UserDefaultToken: String {
+    case accessToken
+    case refreshToken
+}

--- a/Going-iOS/Network/Base/BaseResponse.swift
+++ b/Going-iOS/Network/Base/BaseResponse.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-struct BaseResponse<T: Response>: Response {
-    let status: String
-    let message: String
+struct BaseResponse<T: Codable>: Codable, DTO {
+    let status: Int
     let code: String
+    let message: String
     let data: T?
 }

--- a/Going-iOS/Network/Base/NetworkRequest.swift
+++ b/Going-iOS/Network/Base/NetworkRequest.swift
@@ -7,22 +7,30 @@
 
 import Foundation
 
+enum LoginType {
+    case withJWT
+    case withRefresh
+    case withSocialToken
+}
+
 struct NetworkRequest {
     let path: String
     let httpMethod: HttpMethod
     let query: Request?
     let body: Data?
     let header: [String: String]?
+    let kakaoToken: String?
 
-    init(path: String, httpMethod: HttpMethod, query: Request? = nil, body: Data? = nil, header: [String : String]? = nil) {
+    init(path: String, httpMethod: HttpMethod, query: Request? = nil, body: Data? = nil, header: [String : String]? = nil, kakaoToken: String? = "") {
         self.path = path
         self.httpMethod = httpMethod
         self.query = query
         self.body = body
         self.header = header
+        self.kakaoToken = kakaoToken
     }
 
-    func makeURLRequest() throws -> URLRequest {
+    func makeURLRequest(networkType: LoginType) throws -> URLRequest {
         var urlComponents = URLComponents(string: Config.baseURL)
 
         //Service객체에서 바디나 쿼리가 필요하면 아래와 같이 사용
@@ -56,14 +64,21 @@ struct NetworkRequest {
         var urlRequest = URLRequest(url: urlRequestURL)
         urlRequest.httpMethod = self.httpMethod.rawValue
         urlRequest.setValue(ContentType.json.rawValue, forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
-
-//        if isLogined {
-//            guard let token = UserDefaultsManager.tokenKey?.accessToken else {
-//                throw NetworkError.clientError(code: "", message: "알 수 없는 에러: 회원가입까지 마쳤는데 JWT가 저장되있지 않는 상태")
-//            }
-//            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
-//        }
-
+        
+        switch networkType {
+        case .withJWT:
+            guard let token = UserDefaults.standard.string(forKey: UserDefaultToken.accessToken.rawValue) else {  throw NetworkError.clientError(message: "AccessToken 없음") }
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
+            
+        case .withRefresh:
+            guard let token = UserDefaults.standard.string(forKey: UserDefaultToken.refreshToken.rawValue) else {  throw NetworkError.clientError(message: "RefreshToken 없음") }
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
+            
+        case .withSocialToken:
+            guard let token = kakaoToken else { throw NetworkError.clientError(message: "kakaoToken 없음") }
+            urlRequest.setValue("\(token)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
+        }
+    
         urlRequest.httpBody = self.body
 
         return urlRequest

--- a/Going-iOS/Network/DTO/Auth/Request/LoginRequestDTO.swift
+++ b/Going-iOS/Network/DTO/Auth/Request/LoginRequestDTO.swift
@@ -1,0 +1,14 @@
+//
+//  LoginRequestDTO.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/12/24.
+//
+
+import Foundation
+
+//로그인 통신할 때, 애플인지 카카오 인지
+//String(apple, kakao)
+struct LoginRequestDTO: DTO, Request {
+    let platform: String
+}

--- a/Going-iOS/Network/DTO/Auth/Response/LoginResponseDTO.swift
+++ b/Going-iOS/Network/DTO/Auth/Response/LoginResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  LoginDTO.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/12/24.
+//
+
+import Foundation
+
+//isResult가 true -> 대쉬보드
+//isResult가 false -> 성향테스트스플래시
+struct LoginResponseDTO: Codable, DTO {
+    let accessToken, refreshToken: String
+    let isResult: Bool
+}

--- a/Going-iOS/Network/Services/AuthService.swift
+++ b/Going-iOS/Network/Services/AuthService.swift
@@ -1,0 +1,47 @@
+//
+//  AuthService.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/12/24.
+//
+
+import UIKit
+
+final class AuthService: Serviceable {
+    
+    static let shared = AuthService()
+    
+    private init() {}
+    
+    func login(kakaoToken: String, platform: String) async throws -> Bool {
+        
+        let platformDTO = LoginRequestDTO(platform: platform)
+        let param = platformDTO.toDictionary()
+        let body = try JSONSerialization.data(withJSONObject: param)
+        
+        let urlRequest = try NetworkRequest(path: "/api/users/signin", httpMethod: .post, body: body, kakaoToken: kakaoToken).makeURLRequest(networkType: .withSocialToken)
+        
+        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+        
+        guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: LoginResponseDTO.self) else { throw NetworkError.jsonDecodingError }
+        
+        let access = model.accessToken
+        let refresh = model.refreshToken
+        let isToDashBoardView = model.isResult
+        
+        print(access)
+        print(refresh)
+        //UserDefaults에 jwt토큰 저장
+        UserDefaults.standard.set(access, forKey: UserDefaultToken.accessToken.rawValue)
+        UserDefaults.standard.set(refresh, forKey: UserDefaultToken.refreshToken.rawValue)
+    
+        
+        // true면 LoginVC에서 대시보드뷰로 이동
+        // false면 LoginVC에서 성향테스트스플래시뷰로 이동
+        if isToDashBoardView {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
+++ b/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
@@ -13,13 +13,36 @@ import KakaoSDKUser
 import SnapKit
 
 
-final class LoginViewController: UIViewController {
+final class LoginViewController: UIViewController, ViewControllerServiceable {
     
+    func handleError(_ error: NetworkError) {
+        switch error {
+        case .clientError(let message):
+            DOOToast.show(message: "\(message)", insetFromBottom: 80)
+        default:
+            DOOToast.show(message: error.description, insetFromBottom: 80)
+            
+        }
+    }
+
     private var kakaoAccessToken: String? {
         didSet {
             guard let token = kakaoAccessToken else { return }
-            print("여기서 로그인에이피아이이ㅣ이")
+            
             //로그인API
+            Task {
+                do {
+                    let isPushToDashView = try await AuthService.shared.login(kakaoToken: token, platform: "kakao")
+                    //true면 대시보드로 이동
+                    //false면 성향테스트스플래시뷰로 이동
+                    print(isPushToDashView)
+                    
+                }
+                catch {
+                    guard let error = error as? NetworkError else { return }
+                    handleError(error)
+                }
+            }
         }
     }
     

--- a/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
+++ b/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
@@ -8,10 +8,20 @@
 import UIKit
 
 import AuthenticationServices
+import KakaoSDKAuth
+import KakaoSDKUser
 import SnapKit
 
 
 final class LoginViewController: UIViewController {
+    
+    private var kakaoAccessToken: String? {
+        didSet {
+            guard let token = kakaoAccessToken else { return }
+            print("여기서 로그인에이피아이이ㅣ이")
+            //로그인API
+        }
+    }
     
     private let titleLabel = DOOLabel(font: .pretendard(.head3), color: .gray500, text: StringLiterals.Login.title)
     
@@ -117,16 +127,44 @@ private extension LoginViewController {
         }
     }
     
-    private func setStyle() {
+    func setStyle() {
         self.view.backgroundColor = .white000
+    }
+    
+
+    private func loginKakaoWithApp() {
+        UserApi.shared.loginWithKakaoTalk { oAuthToken, error in
+            guard error == nil else { return }
+            print("Login with KAKAO App Success !!")
+            guard let oAuthToken = oAuthToken else { return }
+            print(oAuthToken.accessToken)
+            self.kakaoAccessToken = oAuthToken.accessToken
+
+        }
+    }
+    
+    private func loginKakaoWithWeb() {
+        UserApi.shared.loginWithKakaoAccount { oAuthToken, error in
+            guard error == nil else { return }
+            print("Login with KAKAO Web Success !!")
+            guard let oAuthToken = oAuthToken else { return }
+            print(oAuthToken.accessToken)
+            self.kakaoAccessToken = oAuthToken.accessToken
+        }
     }
     
     @objc
     func kakaoLoginButtonTapped() {
         
+        //카카오톡앱이 있으면 카카오앱으로 연결, 없으면 웹을 띄워줌
+        if UserApi.isKakaoTalkLoginAvailable() {
+            loginKakaoWithApp()
+        } else {
+            loginKakaoWithWeb()
+        }
         //뷰연결 테스트용도
-        let nextVC = MakeProfileViewController()
-        self.navigationController?.pushViewController(nextVC, animated: true)
+//        let nextVC = MakeProfileViewController()
+//        self.navigationController?.pushViewController(nextVC, animated: true)
     }
     
     @objc
@@ -172,10 +210,11 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
     }
 }
 
+
 extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return self.view.window!
     }
-    
-    
 }
+
+


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- /#80

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 카카오로그인 구현
- 네트워크 세팅 분기처리(NetworkRequest)
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### 네트워크 세팅 분기처리
저희 팀 API 명세서를 보면 헤더(Authorization)에 들어가는 값이 3가지 경우로 나뉩니다.
JWTRefreshToken, 카카오AccessToken, JWTAccessToken으로 나뉩니다.
그래서 Network파일에 LoginType enum을 생성해 case 분리를 해주었습니다.
또한 JWT토큰은 UserDefaults에 저장해두지만, 카카오토큰은 로그인을 할 때, 바로 보내주기 때문에 따로 매개변수로 받아올 수 있도록 Network 메서드에 추가하였습니다.

```swift

enum LoginType {
    case withJWT
    case withRefresh
    case withSocialToken
}

struct NetworkRequest {
    let path: String
    let httpMethod: HttpMethod
    let query: Request?
    let body: Data?
    let header: [String: String]?
    let kakaoToken: String?

    init(path: String, httpMethod: HttpMethod, query: Request? = nil, body: Data? = nil, header: [String : String]? = nil, kakaoToken: String? = "") {
        self.path = path
        self.httpMethod = httpMethod
        self.query = query
        self.body = body
        self.header = header
        self.kakaoToken = kakaoToken
    }

    func makeURLRequest(networkType: LoginType) throws -> URLRequest {
        var urlComponents = URLComponents(string: Config.baseURL)
```

그리고 아래에서 3가지 분기처리에 따른 헤더를 추가해주었습니다
```swift
 urlRequest.setValue(ContentType.json.rawValue, forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
        
        switch networkType {
        case .withJWT:
            guard let token = UserDefaults.standard.string(forKey: UserDefaultToken.accessToken.rawValue) else {  throw NetworkError.clientError(message: "AccessToken 없음") }
            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
            
        case .withRefresh:
            guard let token = UserDefaults.standard.string(forKey: UserDefaultToken.refreshToken.rawValue) else {  throw NetworkError.clientError(message: "RefreshToken 없음") }
            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
            
        case .withSocialToken:
            guard let token = kakaoToken else { throw NetworkError.clientError(message: "kakaoToken 없음") }
            urlRequest.setValue("\(token)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
        }
    
        urlRequest.httpBody = self.body

        return urlRequest
    }
```


### 카카오 로그인
AuthService를 만들어서 login 메서드를 만들었습니다. 
매개변수로 kakaoToken과 platform을 만들었습니다. (애플로그인도 있기 때문에)
그리고 리턴값으로 구조체를 받는 것이 아닌 bool값으로 만들어서 LoginVC에서 어디로 보낼 지에 대한 분기처리를 해주었습니다.
그리고 서버로부터 토큰을 받아와서 UserDefault에 추가해주었습니다.

```swift
func login(kakaoToken: String, platform: String) async throws -> Bool {
        
        let platformDTO = LoginRequestDTO(platform: platform)
        let param = platformDTO.toDictionary()
        let body = try JSONSerialization.data(withJSONObject: param)
        
        let urlRequest = try NetworkRequest(path: "/api/users/signin", httpMethod: .post, body: body, kakaoToken: kakaoToken).makeURLRequest(networkType: .withSocialToken)
        
        let (data, _) = try await URLSession.shared.data(for: urlRequest)
        
        guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: LoginResponseDTO.self) else { throw NetworkError.jsonDecodingError }
        
        let access = model.accessToken
        let refresh = model.refreshToken
        let isToDashBoardView = model.isResult
        
        print(access)
        print(refresh)
        //UserDefaults에 jwt토큰 저장
        UserDefaults.standard.set(access, forKey: UserDefaultToken.accessToken.rawValue)
        UserDefaults.standard.set(refresh, forKey: UserDefaultToken.refreshToken.rawValue)
    
        
        // true면 LoginVC에서 대시보드뷰로 이동
        // false면 LoginVC에서 성향테스트스플래시뷰로 이동
        if isToDashBoardView {
            return true
        } else {
            return false
        }
    }
```

### 고민거리
- 로그인을 처음 하다 보니 이런 식으로 분기처리를 하는게 맞는 지 잘 모르겠습니다.
더 좋은 방법이 있으면 알려주세요

- 애플로그인이 추가되면 다시 로직을 짜야될 것 같습니다. 
현재는 카카오만 한다는 가정으로 만들었습니다.

- 현재 에러코드를 대응하지 않고 있는데, 추후에 에러코드에 따른 토스트메세지를 띄우도록 하겠습니다.


## 📟 관련 이슈
- Resolved: #80
