### PR TITLE
[FEAT] 애플 로그인 구현 (#84)

### DIFF
--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		F4FE6B942B50863D009C935E /* SocialPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B932B50863D009C935E /* SocialPlatform.swift */; };
 		F4FE6B982B508B95009C935E /* OurToDoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B962B508B3F009C935E /* OurToDoService.swift */; };
 		F4FE6B9C2B508C2C009C935E /* MyToDoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B9A2B508BFB009C935E /* MyToDoService.swift */; };
+		F4FE6B9E2B50AAE2009C935E /* SignUpRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B9D2B50AAE2009C935E /* SignUpRequestDTO.swift */; };
+		F4FE6BA02B50AB46009C935E /* SignUpResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B9F2B50AB46009C935E /* SignUpResponseDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -278,6 +280,8 @@
 		F4FE6B932B50863D009C935E /* SocialPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialPlatform.swift; sourceTree = "<group>"; };
 		F4FE6B962B508B3F009C935E /* OurToDoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OurToDoService.swift; sourceTree = "<group>"; };
 		F4FE6B9A2B508BFB009C935E /* MyToDoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyToDoService.swift; sourceTree = "<group>"; };
+		F4FE6B9D2B50AAE2009C935E /* SignUpRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequestDTO.swift; sourceTree = "<group>"; };
+		F4FE6B9F2B50AB46009C935E /* SignUpResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpResponseDTO.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1090,6 +1094,7 @@
 			isa = PBXGroup;
 			children = (
 				F4FE6B8F2B5051E4009C935E /* LoginResponseDTO.swift */,
+				F4FE6B9F2B50AB46009C935E /* SignUpResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1098,6 +1103,7 @@
 			isa = PBXGroup;
 			children = (
 				F4FE6B8D2B50514F009C935E /* LoginRequestDTO.swift */,
+				F4FE6B9D2B50AAE2009C935E /* SignUpRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1211,6 +1217,7 @@
 				F4FE6B922B50861A009C935E /* LoginType.swift in Sources */,
 				CA8CD69E2B47F60C00CFDFBF /* ToDoViewController.swift in Sources */,
 				F49B352A2B35E9BD0080A19F /* UIStackView+.swift in Sources */,
+				F4FE6B9E2B50AAE2009C935E /* SignUpRequestDTO.swift in Sources */,
 				94C2C9AE2B470ACD00B92CAC /* DatePickerView.swift in Sources */,
 				CA8CD6812B46B70700CFDFBF /* TripHeaderView.swift in Sources */,
 				F44D98602B4EB70500341893 /* HTTPHeaderField.swift in Sources */,
@@ -1306,6 +1313,7 @@
 				F49B352E2B35EB270080A19F /* CALayer+.swift in Sources */,
 				F44461092B4D8EB300674D74 /* PopUpDimmedViewController.swift in Sources */,
 				F4BA26FC2B471A1800975CC2 /* Constant.swift in Sources */,
+				F4FE6BA02B50AB46009C935E /* SignUpResponseDTO.swift in Sources */,
 				94747F592B4FE13400510226 /* OurTestResultView.swift in Sources */,
 				F485D48F2B47CF9B007317F4 /* UserTestViewController.swift in Sources */,
 				94747F5B2B4FE15C00510226 /* TestProgressView.swift in Sources */,

--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -137,6 +137,8 @@
 		F4FE6B9C2B508C2C009C935E /* MyToDoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B9A2B508BFB009C935E /* MyToDoService.swift */; };
 		F4FE6B9E2B50AAE2009C935E /* SignUpRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B9D2B50AAE2009C935E /* SignUpRequestDTO.swift */; };
 		F4FE6BA02B50AB46009C935E /* SignUpResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6B9F2B50AB46009C935E /* SignUpResponseDTO.swift */; };
+		F4FE6BA32B50AF26009C935E /* UserProfileAppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6BA22B50AF26009C935E /* UserProfileAppData.swift */; };
+		F4FE6BA52B50B401009C935E /* IsAppleLogined.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE6BA42B50B401009C935E /* IsAppleLogined.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -282,6 +284,8 @@
 		F4FE6B9A2B508BFB009C935E /* MyToDoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyToDoService.swift; sourceTree = "<group>"; };
 		F4FE6B9D2B50AAE2009C935E /* SignUpRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequestDTO.swift; sourceTree = "<group>"; };
 		F4FE6B9F2B50AB46009C935E /* SignUpResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpResponseDTO.swift; sourceTree = "<group>"; };
+		F4FE6BA22B50AF26009C935E /* UserProfileAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileAppData.swift; sourceTree = "<group>"; };
+		F4FE6BA42B50B401009C935E /* IsAppleLogined.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsAppleLogined.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -757,6 +761,7 @@
 		F4BA26F32B45597600975CC2 /* MakeProfile */ = {
 			isa = PBXGroup;
 			children = (
+				F4FE6BA12B50AEEF009C935E /* Models */,
 				F485D4902B47DDBE007317F4 /* ViewControllers */,
 			);
 			path = MakeProfile;
@@ -857,6 +862,7 @@
 			isa = PBXGroup;
 			children = (
 				F4F5218B2B346373000E6E1E /* UserDefaultToken.swift */,
+				F4FE6BA42B50B401009C935E /* IsAppleLogined.swift */,
 			);
 			path = UserDefault;
 			sourceTree = "<group>";
@@ -1117,6 +1123,14 @@
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
+		F4FE6BA12B50AEEF009C935E /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				F4FE6BA22B50AF26009C935E /* UserProfileAppData.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1296,6 +1310,7 @@
 				F4F5218C2B346373000E6E1E /* UserDefaultToken.swift in Sources */,
 				F4C5E7862B42A9C80008735F /* LoginViewController.swift in Sources */,
 				F44D98622B4EB72300341893 /* NetworkError.swift in Sources */,
+				F4FE6BA32B50AF26009C935E /* UserProfileAppData.swift in Sources */,
 				94C7DDBC2B4CA08800541567 /* DOONavigationBar.swift in Sources */,
 				CA3EEE442B50276500C23A41 /* GetOurToDoResponseDTO.swift in Sources */,
 				9478E53C2B4EFCB90027606D /* MyProfileViewController.swift in Sources */,
@@ -1315,6 +1330,7 @@
 				F4BA26FC2B471A1800975CC2 /* Constant.swift in Sources */,
 				F4FE6BA02B50AB46009C935E /* SignUpResponseDTO.swift in Sources */,
 				94747F592B4FE13400510226 /* OurTestResultView.swift in Sources */,
+				F4FE6BA52B50B401009C935E /* IsAppleLogined.swift in Sources */,
 				F485D48F2B47CF9B007317F4 /* UserTestViewController.swift in Sources */,
 				94747F5B2B4FE15C00510226 /* TestProgressView.swift in Sources */,
 				F4FE6B872B504C8C009C935E /* AuthService.swift in Sources */,

--- a/Going-iOS/Application/AppDelegate.swift
+++ b/Going-iOS/Application/AppDelegate.swift
@@ -24,29 +24,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CheckPhotoAccessProtocol 
         let kakaoNativeAppKey = Config.kakaoNativeAppKey
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
         
-        let appleIDProvider = ASAuthorizationAppleIDProvider()
-        appleIDProvider.getCredentialState(forUserID: "여기에 credential.user 넣기") { (credentialState, error) in
-            switch credentialState {
-            case .authorized:
-                print("authorized")
-                // The Apple ID credential is valid.
-                //                   DispatchQueue.main.async {
-                //                     //authorized된 상태이므로 바로 로그인 완료 화면으로 이동
-                //                     self.window?.rootViewController = ViewController()
-                //                   }
-            case .revoked:
-                print("revoked")
-            case .notFound:
-                // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
-                print("")
-                
-            default:
-                break
-            }
-        }
         return true
     }
-    
     
     // MARK: UISceneSession Lifecycle
     

--- a/Going-iOS/Application/SceneDelegate.swift
+++ b/Going-iOS/Application/SceneDelegate.swift
@@ -39,16 +39,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneDidBecomeActive(_ scene: UIScene) {
+        
+        //자동로그인
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: "여기에 credential.user 넣기") { (credentialState, error) in
             switch credentialState {
             case .authorized:
                 print("authorized")
-                // The Apple ID credential is valid.
-                //                   DispatchQueue.main.async {
-                //                     //authorized된 상태이므로 바로 로그인 완료 화면으로 이동
-                //                     self.window?.rootViewController = ViewController()
-                //                   }
+                //The Apple ID credential is valid.
+                DispatchQueue.main.async {
+                //authorized된 상태이므로 바로 로그인 완료 화면으로 이동
+//                    self.window?.rootViewController = ViewController()
+                }
             case .revoked:
                 print("revoked")
             case .notFound:

--- a/Going-iOS/Global/Protocols/Serviceable.swift
+++ b/Going-iOS/Global/Protocols/Serviceable.swift
@@ -13,12 +13,12 @@ protocol Serviceable {
     /// - Parameters:
     ///   - data: Data타입의 통신 결과
     ///   - decodeType: Data타입의 통신결과를 해당 타입으로 decode
-    func dataDecodeAndhandleErrorCode<T: Codable>(data: Data, decodeType: T.Type) throws -> T?
+    func dataDecodeAndhandleErrorCode<T: Response>(data: Data, decodeType: T.Type) throws -> T?
 }
 
 extension Serviceable {
     @discardableResult
-    func dataDecodeAndhandleErrorCode<T: Codable>(data: Data, decodeType: T.Type) throws -> T? {
+    func dataDecodeAndhandleErrorCode<T: Response>(data: Data, decodeType: T.Type) throws -> T? {
 
         guard let model = try? JSONDecoder().decode(BaseResponse<T>.self, from: data) else {
             throw NetworkError.jsonDecodingError

--- a/Going-iOS/Global/UserDefault/IsAppleLogined.swift
+++ b/Going-iOS/Global/UserDefault/IsAppleLogined.swift
@@ -1,0 +1,12 @@
+//
+//  IsAppleLogined.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/12/24.
+//
+
+import Foundation
+
+enum IsAppleLogined: String {
+    case isAppleLogin
+}

--- a/Going-iOS/Global/UserDefault/UserDefaultToken.swift
+++ b/Going-iOS/Global/UserDefault/UserDefaultToken.swift
@@ -11,3 +11,4 @@ enum UserDefaultToken: String {
     case accessToken
     case refreshToken
 }
+

--- a/Going-iOS/Network/Base/BaseResponse.swift
+++ b/Going-iOS/Network/Base/BaseResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct BaseResponse<T: Codable>: Codable, DTO {
+struct BaseResponse<T: Response>: Response, DTO {
     let status: Int
     let code: String
     let message: String

--- a/Going-iOS/Network/DTO/Auth/Request/SignUpRequestDTO.swift
+++ b/Going-iOS/Network/DTO/Auth/Request/SignUpRequestDTO.swift
@@ -1,0 +1,14 @@
+//
+//  SignUpRequestDTO.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/12/24.
+//
+
+import Foundation
+
+struct SignUpRequestDTO: DTO, Request {
+    let name: String
+    let intro: String
+    let platform: String
+}

--- a/Going-iOS/Network/DTO/Auth/Response/SignUpResponseDTO.swift
+++ b/Going-iOS/Network/DTO/Auth/Response/SignUpResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpResponseDTO.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/12/24.
+//
+
+import Foundation
+
+struct SignUpResponseDTO: DTO, Response {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Going-iOS/Network/DTO/OurToDo/GetOurToDoResponseDTO.swift
+++ b/Going-iOS/Network/DTO/OurToDo/GetOurToDoResponseDTO.swift
@@ -21,7 +21,7 @@ struct Participant: DTO, Response {
 }
 
 extension GetOurToDoResponseDTO {
-    func toAppData() -> OurToDoHeaderAppData {
-        return OurToDoHeaderAppData(title: self.title, day: self.day, startDate: self.startDate, endDate: self.endDate, progress: self.progress, participants: self.participants)
-    }
+//    func toAppData() -> OurToDoHeaderAppData {
+//        return OurToDoHeaderAppData(title: self.title, day: self.day, startDate: self.startDate, endDate: self.endDate, progress: self.progress, participants: self.participants)
+//    }
 }

--- a/Going-iOS/Network/Services/AuthService.swift
+++ b/Going-iOS/Network/Services/AuthService.swift
@@ -41,4 +41,27 @@ final class AuthService: Serviceable {
             return false
         }
     }
+    
+    func signUp(token: String, signUpBody: SignUpRequestDTO) async throws {
+        
+        let signUpDTO = signUpBody
+        let param = signUpDTO.toDictionary()
+        let body = try JSONSerialization.data(withJSONObject: param)
+        
+        let urlRequest = try NetworkRequest(path: "/api/users/signup", httpMethod: .post, body: body, token: token).makeURLRequest(networkType: .withSocialToken)
+        
+        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+        
+        guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: SignUpResponseDTO.self) else { throw NetworkError.jsonDecodingError }
+        
+        let access = model.accessToken
+        let refresh = model.refreshToken
+        
+        //UserDefaults에 jwt토큰 저장
+        UserDefaults.standard.set(access, forKey: UserDefaultToken.accessToken.rawValue)
+        UserDefaults.standard.set(refresh, forKey: UserDefaultToken.refreshToken.rawValue)
+        
+        print("회원가입성공!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+                
+    }
 }

--- a/Going-iOS/Network/Services/AuthService.swift
+++ b/Going-iOS/Network/Services/AuthService.swift
@@ -29,14 +29,10 @@ final class AuthService: Serviceable {
         let refresh = model.refreshToken
         let isToDashBoardView = model.isResult
         
-        print(access)
-        print(refresh)
-        
         //UserDefaults에 jwt토큰 저장
         UserDefaults.standard.set(access, forKey: UserDefaultToken.accessToken.rawValue)
         UserDefaults.standard.set(refresh, forKey: UserDefaultToken.refreshToken.rawValue)
     
-        
         // true면 LoginVC에서 대시보드뷰로 이동
         // false면 LoginVC에서 성향테스트스플래시뷰로 이동
         if isToDashBoardView {

--- a/Going-iOS/Network/Services/MyToDoService.swift
+++ b/Going-iOS/Network/Services/MyToDoService.swift
@@ -16,7 +16,7 @@ final class MyToDoService: Serviceable {
     func getMyToDoHeader(tripId: Int) async throws -> MyToDoHeaderAppData {
         
         /// 1. URLRequest 생성
-        let urlRequest = try NetworkRequest(path: "/api/trips/\(tripId)/my", httpMethod: .get).makeURLRequest()
+        let urlRequest = try NetworkRequest(path: "/api/trips/\(tripId)/my", httpMethod: .get).makeURLRequest(networkType: .withJWT)
         /// 2. 서버통신
         let (data, _) = try await URLSession.shared.data(for: urlRequest)
         /// 3. 에러 핸들링

--- a/Going-iOS/Network/Services/OurToDoService.swift
+++ b/Going-iOS/Network/Services/OurToDoService.swift
@@ -1,20 +1,20 @@
-import UIKit
-
-final class OurToDoService: Serviceable {
-    
-    static let shared = OurToDoService()
-    
-    private init() {}
-    
-    func getOurToDoHeader(tripId: Int) async throws -> OurToDoHeaderAppData {
-        let urlRequest = try NetworkRequest(path: "/api/trips/\(tripId)/our", httpMethod: .get).makeURLRequest()
-        
-        let (data, _) = try await URLSession.shared.data(for: urlRequest)
-        
-        guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: GetOurToDoResponseDTO.self) else { return OurToDoHeaderAppData.EmptyData }
-        
-        return model.toAppData()
-    }
-}
-
-
+//import UIKit
+//
+//final class OurToDoService: Serviceable {
+//    
+//    static let shared = OurToDoService()
+//    
+//    private init() {}
+//    
+//    func getOurToDoHeader(tripId: Int) async throws -> OurToDoHeaderAppData {
+//        let urlRequest = try NetworkRequest(path: "/api/trips/\(tripId)/our", httpMethod: .get).makeURLRequest(networkType: .withJWT)
+//        
+//        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+//        
+//        guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: GetOurToDoResponseDTO.self) else { return OurToDoHeaderAppData.EmptyData }
+//        
+//        return model.toAppData()
+//    }
+//}
+//
+//

--- a/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
+++ b/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
@@ -218,7 +218,6 @@ extension LoginViewController: ViewControllerServiceable {
             DOOToast.show(message: error.description, insetFromBottom: 80)
         }
     }
-    
 }
 
 //애플로그인

--- a/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
+++ b/Going-iOS/Scene/Login/ViewControllers/LoginViewController.swift
@@ -153,6 +153,7 @@ private extension LoginViewController {
             guard error == nil else { return }
             print("Login with KAKAO App Success !!")
             guard let oAuthToken = oAuthToken else { return }
+            UserDefaults.standard.set(false, forKey: IsAppleLogined.isAppleLogin.rawValue)
             self.socialType = .kakao
             self.socialToken = oAuthToken.accessToken
             
@@ -167,6 +168,7 @@ private extension LoginViewController {
                 return }
             print("Login with KAKAO Web Success !!")
             guard let oAuthToken = oAuthToken else { return }
+            UserDefaults.standard.set(false, forKey: IsAppleLogined.isAppleLogin.rawValue)
             self.socialType = .kakao
             self.socialToken = oAuthToken.accessToken
             
@@ -194,9 +196,6 @@ private extension LoginViewController {
         controller.presentationContextProvider = self
         controller.performRequests()
         
-        //뷰연결용
-        //        let nextVC = MakeProfileViewController()
-        //        self.navigationController?.pushViewController(nextVC, animated: true)
     }
     
     @objc
@@ -231,6 +230,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
                 DOOToast.show(message: "애플로그인에 실패하셨습니다.", insetFromBottom: 80)
                 return
             }
+            UserDefaults.standard.set(true, forKey: IsAppleLogined.isAppleLogin.rawValue)
             self.socialType = .apple
             self.socialToken = String(data: userIdentifier, encoding: .utf8)
             // .authorizationCode와 .identityToken은 Generate and valid tokens, revoke tokens에서 사용

--- a/Going-iOS/Scene/MakeProfile/Models/UserProfileAppData.swift
+++ b/Going-iOS/Scene/MakeProfile/Models/UserProfileAppData.swift
@@ -1,0 +1,20 @@
+//
+//  UserProfileAppData.swift
+//  Going-iOS
+//
+//  Created by 곽성준 on 1/12/24.
+//
+
+import Foundation
+
+struct UserProfileAppData: AppData {
+    var name: String
+    var intro: String
+    var platform: String
+}
+
+extension UserProfileAppData {
+    func toDTOData() -> SignUpRequestDTO {
+        return SignUpRequestDTO(name: self.name, intro: self.intro, platform: self.platform)
+    }
+}

--- a/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
+++ b/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
@@ -9,13 +9,9 @@ import UIKit
 
 import SnapKit
 
-//나중에 서버한테 넘겨줄 때
-struct UserProfileData {
-    var name: String
-    var description: String
-}
-
 final class MakeProfileViewController: UIViewController {
+    
+    private var userProfileData: UserProfileAppData?
     
     private let nameLabel = DOOLabel(font: .pretendard(.body2_bold),
                                      color: .gray700,
@@ -311,24 +307,50 @@ private extension MakeProfileViewController {
     
     @objc
     func nextButtonTapped() {
-        
-        //구조체에 넣어서 서버에 넘겨주기
-        var userData = UserProfileData(name: "", description: "")
-        
+                
         if let nameText = nameTextField.text {
-            userData.name = nameText
+            self.userProfileData?.name = nameText
         }
         
         if let descText = descTextField.text {
-            userData.description = descText
+            self.userProfileData?.intro = descText
         }
         
-        // userData를 출력 또는 다음 단계로 전달하는 등의 동작 수행
-        //        print(userData.name)
-        //        print(userData.description)
+        if UserDefaults.standard.bool(forKey: IsAppleLogined.isAppleLogin.rawValue) {
+            self.userProfileData?.platform = SocialPlatform.apple.rawValue
+        } else {
+            self.userProfileData?.platform = SocialPlatform.kakao.rawValue
+        }
+        
+        //회원가입API
+        guard let token = UserDefaults.standard.string(forKey: UserDefaultToken.accessToken.rawValue) else { return }
+        guard let signUpBody = self.userProfileData?.toDTOData() else { return }
+        
+        Task {
+            do {
+                let data = try await AuthService.shared.signUp(token: token, signUpBody: signUpBody)
+            }
+            catch {
+                guard let error = error as? NetworkError else { return }
+                handleError(error)
+            }
+        }
+
         let nextVC = UserTestSplashViewController()
         self.navigationController?.pushViewController(nextVC, animated: true)
         
+    }
+}
+
+extension MakeProfileViewController: ViewControllerServiceable {
+    //추후에 에러코드에 따른 토스트 메세지 구현해야됨
+    func handleError(_ error: NetworkError) {
+        switch error {
+        case .clientError(let message):
+            DOOToast.show(message: "\(message)", insetFromBottom: 80)
+        default:
+            DOOToast.show(message: error.description, insetFromBottom: 80)
+        }
     }
 }
 

--- a/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
+++ b/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
@@ -354,7 +354,7 @@ extension MakeProfileViewController: UITextFieldDelegate {
         }
         
         //모든 예시는 NameTextField 기준으로 적음
-        var oldText = textField.text ?? "" // 입력하기 전 textField에 표시되어있던 text 입니다.
+        let oldText = textField.text ?? "" // 입력하기 전 textField에 표시되어있던 text 입니다.
         let addedText = string // 입력한 text 입니다.
         let newText = oldText + addedText // 입력하기 전 text와 입력한 후 text를 합칩니다.
         let newTextLength = newText.count // 합쳐진 text의 길이 입니다.
@@ -391,7 +391,7 @@ extension MakeProfileViewController: UITextFieldDelegate {
     
     //TextField에 변경사항이 생기면, TextField에 작성된 후에 호출되는 메서드
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        var text = textField.text ?? ""
+        let text = textField.text ?? ""
         var maxLength = 0
         switch textField {
         case nameTextField:

--- a/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
+++ b/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
@@ -70,7 +70,7 @@ final class OurToDoViewController: UIViewController {
             let newEndDate = "\(splitEndDate[1])월 \(splitEndDate[2])일"
             self.tripHeaderView.tripData = [data.title, "\(data.day)", newStartDate, newEndDate]
             self.tripMiddleView.progress = data.progress
-            self.tripMiddleView.participants = data.participants
+//            self.tripMiddleView.participants = data.participants
         }
     }
     var ourToDoData: OurToDoData?


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- #84

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 애플로그인 구현
- 애플로그인, 카카오로그인 분기처리
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 애플로그인
추후에 분기처리를 위해 isAppleLogined를 UserDefualt에 저장시켰습니다.
애플로그인에 성공하면 Userdefault에 isAppleLogined를 true로 바꿔줍니다.
그리고 카카로 로그인에 성공하면 false로 바꿔줍니다.
```swift
//애플로그인
extension LoginViewController: ASAuthorizationControllerDelegate {
    
    //애플로그인 성공했을 때
    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
        
        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
            guard let userIdentifier = credential.identityToken else {
                DOOToast.show(message: "애플로그인에 실패하셨습니다.", insetFromBottom: 80)
                return
            }
            UserDefaults.standard.set(true, forKey: IsAppleLogined.isAppleLogin.rawValue)
            self.socialType = .apple
            self.socialToken = String(data: userIdentifier, encoding: .utf8)
            // .authorizationCode와 .identityToken은 Generate and valid tokens, revoke tokens에서 사용
        }
    }
    
    //애플로그인 실패했을 때
    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
        
        print("login failed - \(error.localizedDescription)")
        
    }
}
```


## 📟 관련 이슈
- Resolved: #84
