### PR TITLE
[FEAT]  초대코드 검증 API 서버통신 (#78)

### DIFF
--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		941B1B782B50EB0C00D28EBA /* CodeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B1B772B50EB0C00D28EBA /* CodeResponseDTO.swift */; };
+		941B1B7C2B50ECED00D28EBA /* JoiningSuccessAppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B1B7B2B50ECED00D28EBA /* JoiningSuccessAppData.swift */; };
+		941B1B812B51089400D28EBA /* CodeRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B1B802B51089400D28EBA /* CodeRequestDTO.swift */; };
+		941B1B832B510D9D00D28EBA /* CreateTravelRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B1B822B510D9D00D28EBA /* CreateTravelRequestDTO.swift */; };
+		941B1B852B510F3C00D28EBA /* CreateTravelResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B1B842B510F3C00D28EBA /* CreateTravelResponseDTO.swift */; };
+		941B1B872B510FB800D28EBA /* CreatingSuccessAppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B1B862B510FB800D28EBA /* CreatingSuccessAppData.swift */; };
+		941B1B892B5138B400D28EBA /* TravelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B1B882B5138B400D28EBA /* TravelService.swift */; };
 		94442EB62B4ABB4A00FDBB26 /* DashBoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94442EB52B4ABB4A00FDBB26 /* DashBoardViewController.swift */; };
 		94442EBA2B4ABC2300FDBB26 /* DashBoardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94442EB92B4ABC2300FDBB26 /* DashBoardCollectionViewCell.swift */; };
 		94442EBD2B4AC6F500FDBB26 /* TravelInfoStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94442EBC2B4AC6F500FDBB26 /* TravelInfoStruct.swift */; };
@@ -151,6 +158,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		941B1B772B50EB0C00D28EBA /* CodeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeResponseDTO.swift; sourceTree = "<group>"; };
+		941B1B7B2B50ECED00D28EBA /* JoiningSuccessAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoiningSuccessAppData.swift; sourceTree = "<group>"; };
+		941B1B802B51089400D28EBA /* CodeRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeRequestDTO.swift; sourceTree = "<group>"; };
+		941B1B822B510D9D00D28EBA /* CreateTravelRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTravelRequestDTO.swift; sourceTree = "<group>"; };
+		941B1B842B510F3C00D28EBA /* CreateTravelResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTravelResponseDTO.swift; sourceTree = "<group>"; };
+		941B1B862B510FB800D28EBA /* CreatingSuccessAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatingSuccessAppData.swift; sourceTree = "<group>"; };
+		941B1B882B5138B400D28EBA /* TravelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelService.swift; sourceTree = "<group>"; };
 		94442EB52B4ABB4A00FDBB26 /* DashBoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashBoardViewController.swift; sourceTree = "<group>"; };
 		94442EB92B4ABC2300FDBB26 /* DashBoardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashBoardCollectionViewCell.swift; sourceTree = "<group>"; };
 		94442EBC2B4AC6F500FDBB26 /* TravelInfoStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelInfoStruct.swift; sourceTree = "<group>"; };
@@ -185,9 +199,7 @@
 		CA3EEE332B4E908E00C23A41 /* InviteFriendPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteFriendPopUpViewController.swift; sourceTree = "<group>"; };
 		CA3EEE382B4FE96E00C23A41 /* GetMyToDoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMyToDoResponseDTO.swift; sourceTree = "<group>"; };
 		CA3EEE3A2B4FED8300C23A41 /* MyToDoHeaderAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyToDoHeaderAppData.swift; sourceTree = "<group>"; };
-		CA3EEE3C2B4FEF8700C23A41 /* MyToDoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyToDoService.swift; sourceTree = "<group>"; };
 		CA3EEE3E2B50221A00C23A41 /* OurToDoHeaderAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OurToDoHeaderAppData.swift; sourceTree = "<group>"; };
-		CA3EEE402B50258700C23A41 /* OurToDoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OurToDoService.swift; sourceTree = "<group>"; };
 		CA3EEE432B50276500C23A41 /* GetOurToDoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOurToDoResponseDTO.swift; sourceTree = "<group>"; };
 		CA8CD6692B46B45200CFDFBF /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Black.otf"; sourceTree = "<group>"; };
 		CA8CD66B2B46B45D00CFDFBF /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
@@ -298,6 +310,41 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		941B1B752B50EAAE00D28EBA /* Trip */ = {
+			isa = PBXGroup;
+			children = (
+				941B1B7F2B51088700D28EBA /* Request */,
+				941B1B762B50EABF00D28EBA /* Response */,
+			);
+			path = Trip;
+			sourceTree = "<group>";
+		};
+		941B1B762B50EABF00D28EBA /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				941B1B772B50EB0C00D28EBA /* CodeResponseDTO.swift */,
+				941B1B842B510F3C00D28EBA /* CreateTravelResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		941B1B7A2B50ECCC00D28EBA /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				941B1B7B2B50ECED00D28EBA /* JoiningSuccessAppData.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		941B1B7F2B51088700D28EBA /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				941B1B802B51089400D28EBA /* CodeRequestDTO.swift */,
+				941B1B822B510D9D00D28EBA /* CreateTravelRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
 		94442EB22B4AB5EF00FDBB26 /* DashBoard */ = {
 			isa = PBXGroup;
 			children = (
@@ -379,6 +426,7 @@
 		946190A32B47FA5100A38A42 /* JoinTravel */ = {
 			isa = PBXGroup;
 			children = (
+				941B1B7A2B50ECCC00D28EBA /* Models */,
 				946190A42B47FA6500A38A42 /* ViewControllers */,
 			);
 			path = JoinTravel;
@@ -405,6 +453,7 @@
 			isa = PBXGroup;
 			children = (
 				94761A092B4E5F5200D7C589 /* CreateTravelStruct.swift */,
+				941B1B862B510FB800D28EBA /* CreatingSuccessAppData.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -799,7 +848,6 @@
 				F4F521732B3440D7000E6E1E /* Going-iOS */,
 				F4F521722B3440D7000E6E1E /* Products */,
 				F4F521BB2B349FDE000E6E1E /* Frameworks */,
-				F4FE6B952B508959009C935E /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -966,6 +1014,7 @@
 		F4F521972B34676D000E6E1E /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				941B1B752B50EAAE00D28EBA /* Trip */,
 				CA3EEE422B50273C00C23A41 /* OurToDo */,
 				CA3EEE372B4FE8AE00C23A41 /* MyToDo */,
 				F4FE6B7D2B4FCC83009C935E /* Profile */,
@@ -981,6 +1030,7 @@
 				F4FE6B962B508B3F009C935E /* OurToDoService.swift */,
 				F41F5D782B4EF431000D0472 /* ToDoService.swift */,
 				F4FE6B862B504C8C009C935E /* AuthService.swift */,
+				941B1B882B5138B400D28EBA /* TravelService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1102,15 +1152,6 @@
 			path = Request;
 			sourceTree = "<group>";
 		};
-		F4FE6B952B508959009C935E /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				CA3EEE3C2B4FEF8700C23A41 /* MyToDoService.swift */,
-				CA3EEE402B50258700C23A41 /* OurToDoService.swift */,
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1205,7 +1246,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				F4FE6B9C2B508C2C009C935E /* MyToDoService.swift in Sources */,
+				941B1B812B51089400D28EBA /* CodeRequestDTO.swift in Sources */,
 				F4FE6B982B508B95009C935E /* OurToDoService.swift in Sources */,
+				941B1B7C2B50ECED00D28EBA /* JoiningSuccessAppData.swift in Sources */,
 				F4FE6B942B50863D009C935E /* SocialPlatform.swift in Sources */,
 				9457F0582B486BC3009ACF25 /* TravelTestQuestionStruct.swift in Sources */,
 				F4FE6B922B50861A009C935E /* LoginType.swift in Sources */,
@@ -1221,6 +1264,7 @@
 				F44D98642B4EB79700341893 /* Serviceable.swift in Sources */,
 				F4C5E7842B42A6830008735F /* UILabel+.swift in Sources */,
 				F44D985A2B4E9ED400341893 /* BaseResponse.swift in Sources */,
+				941B1B782B50EB0C00D28EBA /* CodeResponseDTO.swift in Sources */,
 				F430A98A2B4AD24800D482C4 /* UserTypeTestResultAppData.swift in Sources */,
 				94C7DDBA2B4C77FF00541567 /* SettingsItem.swift in Sources */,
 				9457F04C2B4853AC009ACF25 /* TravelTestViewController.swift in Sources */,
@@ -1245,6 +1289,7 @@
 				F484A3852B3EBC2A00197E3C /* UIColor+.swift in Sources */,
 				F485D48D2B47CF58007317F4 /* UserTestQuestionStruct.swift in Sources */,
 				CA8CD6A42B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift in Sources */,
+				941B1B832B510D9D00D28EBA /* CreateTravelRequestDTO.swift in Sources */,
 				F4C5E7822B429B620008735F /* UIFont+.swift in Sources */,
 				F44D98662B4EB7F700341893 /* NetworkRequest.swift in Sources */,
 				F44D985E2B4EB6E000341893 /* HTTPMethod.swift in Sources */,
@@ -1265,6 +1310,7 @@
 				F44460FD2B4D098B00674D74 /* CheckPhotoAccessProtocol.swift in Sources */,
 				F485D4892B47CB8B007317F4 /* UserTestSplashViewController.swift in Sources */,
 				94442EBD2B4AC6F500FDBB26 /* TravelInfoStruct.swift in Sources */,
+				941B1B892B5138B400D28EBA /* TravelService.swift in Sources */,
 				94761A0A2B4E5F5200D7C589 /* CreateTravelStruct.swift in Sources */,
 				9478E5362B4EF4850027606D /* WebViewController.swift in Sources */,
 				94442EC82B4B18E500FDBB26 /* StartTravelSplashViewController.swift in Sources */,
@@ -1285,6 +1331,7 @@
 				CADA02592B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift in Sources */,
 				F44D98682B4EC71900341893 /* ViewControllerServiceable.swift in Sources */,
 				F44D986C2B4ECACC00341893 /* Token.swift in Sources */,
+				941B1B872B510FB800D28EBA /* CreatingSuccessAppData.swift in Sources */,
 				CA8CD67F2B46B64000CFDFBF /* OurToDoViewController.swift in Sources */,
 				F4F5218C2B346373000E6E1E /* UserDefaultToken.swift in Sources */,
 				F4C5E7862B42A9C80008735F /* LoginViewController.swift in Sources */,
@@ -1306,6 +1353,7 @@
 				F49B352E2B35EB270080A19F /* CALayer+.swift in Sources */,
 				F44461092B4D8EB300674D74 /* PopUpDimmedViewController.swift in Sources */,
 				F4BA26FC2B471A1800975CC2 /* Constant.swift in Sources */,
+				941B1B852B510F3C00D28EBA /* CreateTravelResponseDTO.swift in Sources */,
 				94747F592B4FE13400510226 /* OurTestResultView.swift in Sources */,
 				F485D48F2B47CF9B007317F4 /* UserTestViewController.swift in Sources */,
 				94747F5B2B4FE15C00510226 /* TestProgressView.swift in Sources */,

--- a/Going-iOS/Application/SceneDelegate.swift
+++ b/Going-iOS/Application/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 2.
         self.window = UIWindow(windowScene: windowScene)
         // 3.
-        let navigationController = UINavigationController(rootViewController: LoginViewController())
+        let navigationController = UINavigationController(rootViewController: JoinTravelViewController())
         self.window?.rootViewController = navigationController
         navigationController.isNavigationBarHidden = true
         // 4.

--- a/Going-iOS/Global/Protocols/Serviceable.swift
+++ b/Going-iOS/Global/Protocols/Serviceable.swift
@@ -13,12 +13,12 @@ protocol Serviceable {
     /// - Parameters:
     ///   - data: Data타입의 통신 결과
     ///   - decodeType: Data타입의 통신결과를 해당 타입으로 decode
-    func dataDecodeAndhandleErrorCode<T: Codable>(data: Data, decodeType: T.Type) throws -> T?
+    func dataDecodeAndhandleErrorCode<T: Response>(data: Data, decodeType: T.Type) throws -> T?
 }
 
 extension Serviceable {
     @discardableResult
-    func dataDecodeAndhandleErrorCode<T: Codable>(data: Data, decodeType: T.Type) throws -> T? {
+    func dataDecodeAndhandleErrorCode<T: Response>(data: Data, decodeType: T.Type) throws -> T? {
 
         guard let model = try? JSONDecoder().decode(BaseResponse<T>.self, from: data) else {
             throw NetworkError.jsonDecodingError

--- a/Going-iOS/Network/Base/BaseResponse.swift
+++ b/Going-iOS/Network/Base/BaseResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct BaseResponse<T: Codable>: Codable, DTO {
+struct BaseResponse<T: Response>: Response, DTO {
     let status: Int
     let code: String
     let message: String

--- a/Going-iOS/Network/DTO/Trip/Request/CodeRequestDTO.swift
+++ b/Going-iOS/Network/DTO/Trip/Request/CodeRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  CodeRequestDTO.swift
+//  Going-iOS
+//
+//  Created by 윤영서 on 1/12/24.
+//
+
+import Foundation
+
+struct CodeRequestDTO: DTO, Request {
+    var code: String
+}

--- a/Going-iOS/Network/DTO/Trip/Request/CreateTravelRequestDTO.swift
+++ b/Going-iOS/Network/DTO/Trip/Request/CreateTravelRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  CreateTravelRequestDTO.swift
+//  Going-iOS
+//
+//  Created by 윤영서 on 1/12/24.
+//
+
+import Foundation
+
+struct CreateTravelRequestDTO: Request, DTO {
+    let title, startDate, endDate: String
+    let styleA, styleB, styleC, styleD, styleE: Int
+}

--- a/Going-iOS/Network/DTO/Trip/Response/CodeResponseDTO.swift
+++ b/Going-iOS/Network/DTO/Trip/Response/CodeResponseDTO.swift
@@ -1,0 +1,24 @@
+//
+//  CodeResponseDTO.swift
+//  Going-iOS
+//
+//  Created by 윤영서 on 1/12/24.
+//
+
+import Foundation
+
+struct CodeResponseDTO : Response, DTO {
+    let tripId: Int64
+    let title, startDate, endDate: String
+    let day: Int
+}
+
+extension CodeResponseDTO {
+    func toAppData() -> JoiningSuccessAppData {
+        return JoiningSuccessAppData(travelId: self.tripId,
+                                     travelName: self.title,
+                                     startDate: self.startDate,
+                                     endDate: self.endDate,
+                                     dueDate: self.day)
+    }
+}

--- a/Going-iOS/Network/DTO/Trip/Response/CreateTravelResponseDTO.swift
+++ b/Going-iOS/Network/DTO/Trip/Response/CreateTravelResponseDTO.swift
@@ -1,0 +1,25 @@
+//
+//  CreateTravelResponseDTO.swift
+//  Going-iOS
+//
+//  Created by 윤영서 on 1/12/24.
+//
+
+import Foundation
+
+struct CreateTravelResponseDTO : Response, DTO {
+    let tripId: Int64
+    let title, startDate, endDate, code: String
+    let day: Int
+}
+
+extension CreateTravelResponseDTO {
+    func toCreatingSuccessAppData() -> CreatingSuccessAppData {
+        return CreatingSuccessAppData(travelId: self.tripId,
+                                      travelTitle: self.title,
+                                      startDate: self.startDate,
+                                      endDate: self.endDate,
+                                      inviteCode: self.code,
+                                      dueDate: self.day)
+    }
+}

--- a/Going-iOS/Network/Services/TravelService.swift
+++ b/Going-iOS/Network/Services/TravelService.swift
@@ -1,0 +1,27 @@
+//
+//  TravelService.swift
+//  Going-iOS
+//
+//  Created by 윤영서 on 1/12/24.
+//
+
+import UIKit
+
+final class TravelService: Serviceable {
+    static let shared = TravelService()
+    
+    private init() {}
+    
+    func postInviteCode(code: CodeRequestDTO) async throws -> JoiningSuccessAppData {
+        let param = code.toDictionary()
+        let body = try JSONSerialization.data(withJSONObject: param)
+        let urlRequest = try NetworkRequest(path: "/api/trips/verify", httpMethod: .post, body: body).makeURLRequest(networkType: .withJWT)
+        
+        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+        
+        guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: CodeResponseDTO.self) else { return JoiningSuccessAppData.EmptyData }
+        
+        return model.toAppData()
+    }
+    
+}

--- a/Going-iOS/Scene/CreateTravel/Models/CreatingSuccessAppData.swift
+++ b/Going-iOS/Scene/CreateTravel/Models/CreatingSuccessAppData.swift
@@ -1,0 +1,23 @@
+//
+//  CreatingSuccessAppData.swift
+//  Going-iOS
+//
+//  Created by 윤영서 on 1/12/24.
+//
+
+import Foundation
+
+struct CreatingSuccessAppData: AppData {
+    let travelId: Int64
+    let travelTitle, startDate, endDate, inviteCode: String
+    let dueDate: Int
+}
+
+extension CreatingSuccessAppData {
+    static var EmptyData = CreatingSuccessAppData(travelId: 0, 
+                                                  travelTitle: "",
+                                                  startDate: "",
+                                                  endDate: "",
+                                                  inviteCode: "",
+                                                  dueDate: 0)
+}

--- a/Going-iOS/Scene/CreateTravel/ViewControllers/CreatingSuccessViewController.swift
+++ b/Going-iOS/Scene/CreateTravel/ViewControllers/CreatingSuccessViewController.swift
@@ -28,6 +28,7 @@ final class CreatingSuccessViewController: UIViewController {
     private let ticketImage: UIImageView = {
         let img = UIImageView()
         img.image = ImageLiterals.CreateTravel.ticketLargeImage
+        img.isUserInteractionEnabled = true
         return img
     }()
     
@@ -165,7 +166,7 @@ private extension CreatingSuccessViewController {
         
         codeCopyButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(20)
-            $0.leading.equalToSuperview().inset(112)
+            $0.centerX.equalToSuperview()
             $0.width.equalTo(ScreenUtils.getWidth(110))
             $0.height.equalTo(ScreenUtils.getHeight(20))
         }

--- a/Going-iOS/Scene/JoinTravel/Models/JoiningSuccessAppData.swift
+++ b/Going-iOS/Scene/JoinTravel/Models/JoiningSuccessAppData.swift
@@ -1,0 +1,20 @@
+//
+//  JoiningSuccessAppData.swift
+//  Going-iOS
+//
+//  Created by 윤영서 on 1/12/24.
+//
+
+import Foundation
+
+struct JoiningSuccessAppData: AppData {
+    let travelId: Int64
+    let travelName: String
+    let startDate: String
+    let endDate: String
+    let dueDate: Int
+}
+
+extension JoiningSuccessAppData {
+    static var EmptyData = JoiningSuccessAppData(travelId: 0, travelName: "", startDate: "", endDate: "", dueDate: 0)
+}

--- a/Going-iOS/Scene/JoinTravel/ViewControllers/JoiningSuccessViewController.swift
+++ b/Going-iOS/Scene/JoinTravel/ViewControllers/JoiningSuccessViewController.swift
@@ -10,10 +10,19 @@ import UIKit
 import SnapKit
 
 final class JoiningSuccessViewController: UIViewController {
+        
+    // MARK: - Network
 
-    // MARK: - UI Properties
+    var joinSuccessData: JoiningSuccessAppData? {
+        didSet {
+            guard let data = joinSuccessData else { return }
+            self.travelTitleLabel.text = data.travelName
+            self.dateLabel.text = data.startDate + "-" + data.endDate
+            self.dDayLabel.text = "D-" + "\(data.dueDate)"
+        }
+    }
     
-    // TODO: - Dummy Data 생성
+    // MARK: - UI Properties
     
     private lazy var navigationBar = DOONavigationBar(self, type: .backButtonOnly, backgroundColor: .gray50)
     
@@ -44,7 +53,7 @@ final class JoiningSuccessViewController: UIViewController {
         let label = UILabel()
         label.font = .pretendard(.detail2_bold)
         label.textColor = .red400
-        label.text = "D-16"
+//        label.text = "D-16"
         return label
     }()
     
@@ -52,24 +61,25 @@ final class JoiningSuccessViewController: UIViewController {
         let label = UILabel()
         label.font = .pretendard(.head3)
         label.textColor = .gray700
-        label.text = "두릅과 스페인"
+//        label.text = "두릅과 스페인"
         return label
     }()
+    
     
     private let dateLabel: UILabel = {
         let label = UILabel()
         label.font = .pretendard(.detail3_regular)
         label.textColor = .gray300
-        label.text = "12월 16일 - 12월 25일"
+//        label.text = "12월 16일 - 12월 25일"
         return label
     }()
-
+    
     private lazy var entranceButton: DOOButton = {
         let btn =  DOOButton(type: .enabled, title: StringLiterals.JoiningSuccess.confirmButton)
         btn.addTarget(self, action: #selector(pushToTravelTestVC), for: .touchUpInside)
         return btn
     }()
-   
+    
     // MARK: - Life Cycles
     
     override func viewDidLoad() {
@@ -118,7 +128,7 @@ private extension JoiningSuccessViewController {
             $0.width.equalTo(ScreenUtils.getWidth(320))
             $0.height.equalTo(ScreenUtils.getHeight(300))
         }
-
+        
         dDayLabelBackgroundView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(51)
             $0.centerX.equalTo(joinSuccessLabel)


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
#78 

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 초대코드 검증 API 서버통신 구현했습니다.
- 버튼을 눌렀을 때, Push될 뷰컨트롤러에 데이터를 넣어주는 방식으로 구현했습니다. 
- 올바르지 않은 초대코드 입력 시, warningLabel을 hidden False 처리해주었습니다. 

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
N/A

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src = "" width ="250">|


|기능|스크린샷|
|:--:|:--:|
|아이폰13mini|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #78
