### PR TITLE
[FEAT] 데이트피커 날짜 검증 수정 구현 (#125)

### DIFF
--- a/Going-iOS/Scene/CreateTravel/ViewControllers/CreateTravelViewController.swift
+++ b/Going-iOS/Scene/CreateTravel/ViewControllers/CreateTravelViewController.swift
@@ -263,8 +263,11 @@ private extension CreateTravelViewController {
            let startDate = dateFormatter.date(from: startDateText),
            let endDate = dateFormatter.date(from: endDateText) {
             isDateValid = startDate <= endDate
+            let calendar = Calendar.current
             let today = Date()
-            isEndDateNotPast = endDate >= today
+            if let deletedToday = calendar.date(bySettingHour: 0, minute: 0, second: 0, of: today) {
+                isEndDateNotPast = endDate >= deletedToday
+            }
         }
         
         createTravelButton.currentType = (!isTravelNameTextFieldEmpty

--- a/Going-iOS/Scene/CreateTravel/ViewControllers/DatePickerBottomSheetViewController.swift
+++ b/Going-iOS/Scene/CreateTravel/ViewControllers/DatePickerBottomSheetViewController.swift
@@ -49,6 +49,8 @@ final class DatePickerBottomSheetViewController: UIViewController {
         picker.datePickerMode = .date
         picker.isUserInteractionEnabled = true
         picker.locale = Locale(identifier: "ko-KR")
+        picker.timeZone = TimeZone(identifier: "Asia/Seoul")
+        
         picker.tintColor = .gray700
         if #available(iOS 13.4, *) {
             picker.preferredDatePickerStyle = .wheels

--- a/Going-iOS/Scene/CreateTravel/Views/DatePickerView.swift
+++ b/Going-iOS/Scene/CreateTravel/Views/DatePickerView.swift
@@ -19,6 +19,7 @@ final class DatePickerView: UIView {
         picker.isUserInteractionEnabled = true
         picker.locale = Locale(identifier: "ko-KR")
         picker.tintColor = .gray700
+        picker.timeZone = TimeZone(identifier: "Asia/Seoul")
         if #available(iOS 13.4, *) {
             picker.preferredDatePickerStyle = .wheels
         }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
#125 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
### 투두뷰
- 같은 날짜일 때, Date()를 그대로 받아오면 초까지 받아옵니다.
그래서 몇 초 차이로 다른 날로 인식을 해서 경고 토스트를 띄우는 경우였습니다.
이를 방지하기 위해, Date를 년-월-일만 가져올 수 있도록 구현했습니다.
- 추가로, 데이트피커에서 가져온 값이 string이기에 Date 형식으로 반환해줄 수 있도록 구현했습니다. 

### 여행생성뷰
- 같은 날짜일 때, Date()를 그대로 받아오면 초까지 받아옵니다.
그래서 몇 초 차이로 다른 날로 인식을 해서 이를 방지하기 위해, Date를 년-월-일만 가져올 수 있도록 구현했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
N/A

## 📟 관련 이슈
- Resolved: #125
