### PR TITLE
[FEAT] 데이트피커 관련 로직 수정 (#132)

### DIFF
--- a/Going-iOS/Scene/CreateTravel/ViewControllers/DatePickerBottomSheetViewController.swift
+++ b/Going-iOS/Scene/CreateTravel/ViewControllers/DatePickerBottomSheetViewController.swift
@@ -37,13 +37,7 @@ final class DatePickerBottomSheetViewController: UIViewController {
         view.roundCorners(cornerRadius: 6, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         return view
     }()
-//    
-//    private lazy var datePickerView: DatePickerView = {
-//        let picker = DatePickerView()
-//        picker.datePicker.addTarget(self, action: #selector(datePickerChanged), for: .valueChanged)
-//        return picker
-//    }()
-//    
+
     private lazy var datePickerView: UIDatePicker = {
         let picker = UIDatePicker()
         picker.datePickerMode = .date
@@ -91,6 +85,7 @@ final class DatePickerBottomSheetViewController: UIViewController {
 
     /// UITapGestureRecognizer 연결 메서드
     @objc private func dimmedViewTapped(_ tapRecognizer: UITapGestureRecognizer) {
+        delegate?.didSelectDate(date: datePickerView.date)
         hideBottomSheetAndGoBack()
     }
     
@@ -112,7 +107,6 @@ final class DatePickerBottomSheetViewController: UIViewController {
     
     @objc private func confirmButtonTapped(_ sender: UIButton) {
         delegate?.didSelectDate(date: datePickerView.date)
-//        delegate?.didSelectDate(date: onDate)
         hideBottomSheetAndGoBack()
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
#132 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
### 데이트피커 관련 로직 수정
```swift
func compareDate(userDate: Date) -> Bool {
        let dateFormatter = DateFormatter()
        dateFormatter.dateFormat = "yyyy.MM.dd"
        dateFormatter.timeZone = TimeZone(secondsFromGMT: 32400)

        //유저가 입력한 날짜를 스트링으로 바꿈
        let formattedDateString = dateFormatter.string(from: userDate)
        deadlineTextfieldLabel.text = formattedDateString

        //유저가 선택한 날짜
        let userPickedDate = userDate

        //유저의 위치 날짜
        let today = Date()
        let timezone = TimeZone.autoupdatingCurrent
        let secondsFromGMT = timezone.secondsFromGMT(for: today)

        // 정확한 비교를 위해 시-분-초 절삭한 시간대
        let calendar = Calendar.current
        let deletedUser = calendar.date(bySettingHour: 0, minute: 0, second: 0, of: userPickedDate)
        let deletedToday = calendar.date(bySettingHour: 0, minute: 0, second: 0, of: today)

        // 두 날짜 비교
        if let deletedUser = deletedUser, let deletedToday = deletedToday, deletedUser < deletedToday {
            return false
        } else {
            return true
        }
    }
```
datePicker를 쓰는 뷰에서 날짜 비교를 해야하는 경우가 많았습니다. 
기존에는 아래와 같이 데이트피커에서 받아온 날짜를 Date 형식으로 바꾸어서 오늘날짜와 비교를 해주었습니다. 
```swift
        let formattedDateString = dateFormatter.string(from: date)
        deadlineTextfieldLabel.text = formattedDateString
```

로그를 찍어본 결과, GMT +0 시간으로 지정되어 있었습니다. 또, 데이트피커에서 지정한 날짜가 오늘일 경우, 로그에 찍히는 시간에서 초단위로 차이가 나서 시-분-초는 절삭하고 날짜만 비교하는 로직이 필요했습니다. 따라서, 위의 compareDate 메서드를 만들어서 원하는대로 비교하는 방식을 채택했습니다. 

이후, 날짜 로직이 적절하다면, 버튼을 활성화 할 수 있도록 케이스를 나누어주었습니다.
```swift
        let isAllocatorFilled = (beforeVC == "our") && (buttonIndex.isEmpty == false) || (beforeVC == "my")
        let isTodoTextFieldEmpty = todoTextfield.text!.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
        let isDateSet = deadlineTextfieldLabel.text != "날짜를 선택해주세요."

        var isEndDateNotPast = true

        guard let selectedDate else { return }
        isEndDateNotPast = compareDate(userDate: selectedDate)
        singleButtonView.currentType = ( !isTodoTextFieldEmpty
                                         && isDateSet
                                         && isEndDateNotPast
                                         && isAllocatorFilled) ? .enabled : .unabled
```

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
Allocator 관련 버튼 로직
updateSingleButtonState에 추가 해야합니다.

## 📟 관련 이슈
- Resolved: #132
