### PR TITLE
[HOTFIX] 데이트피커 인디케이터 이슈 해결 및 라이팅 체크 (#155)

### DIFF
--- a/Going-iOS/Global/Literals/StringLiterals.swift
+++ b/Going-iOS/Global/Literals/StringLiterals.swift
@@ -38,7 +38,7 @@ enum StringLiterals {
     enum CreateTravel {
         static let namePlaceHolder = "이번 여행의 이름을 지어주세요"
         static let warning = "여행 이름을 입력해 주세요"
-        static let nameTitle = "새로운 여행 만들기"
+        static let nameTitle = "어떤 여행인가요?"
         static let dateTitle = "여행 일정을 알려주세요"
     }
     

--- a/Going-iOS/Scene/CreateTravel/ViewControllers/DatePickerBottomSheetViewController.swift
+++ b/Going-iOS/Scene/CreateTravel/ViewControllers/DatePickerBottomSheetViewController.swift
@@ -99,6 +99,7 @@ final class DatePickerBottomSheetViewController: UIViewController {
             switch recognizer.direction {
             case .down:
                 hideBottomSheetAndGoBack()
+                delegate?.didSelectDate(date: datePickerView.date)
             default:
                 break
             }

--- a/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
+++ b/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
@@ -63,7 +63,7 @@ final class MakeProfileViewController: UIViewController {
     
     private let descLabel: UILabel = {
         let label = UILabel()
-        label.text = "한 줄 소개"
+        label.text = "한줄 소개"
         label.font = .pretendard(.body2_bold)
         label.textColor = .gray700
         return label
@@ -282,7 +282,7 @@ private extension MakeProfileViewController {
 
                 nameTextField.layer.borderColor = UIColor.red500.cgColor
                 nameTextFieldCountLabel.textColor = .red500
-                nameWarningLabel.text = "닉네임에는 공백만 입력할 수 없어요."
+                nameWarningLabel.text = "닉네임에는 공백만 입력할 수 없어요"
                 nameWarningLabel.isHidden = false
             }  else {
                 nameTextField.layer.borderColor = UIColor.gray700.cgColor
@@ -313,7 +313,7 @@ private extension MakeProfileViewController {
         if text.count > 15 {
             descTextField.layer.borderColor = UIColor.red500.cgColor
             descTextFieldCountLabel.textColor = .red500
-            descWarningLabel.text = "소개는 15자를 초과할 수 없습니다."
+            descWarningLabel.text = "소개는 15자를 초과할 수 없어요"
             descWarningLabel.isHidden = false
             isDescTextFieldGood = false
         } else if text.count == 0 {

--- a/Going-iOS/Scene/Member/ViewControllers/MemberViewController.swift
+++ b/Going-iOS/Scene/Member/ViewControllers/MemberViewController.swift
@@ -48,7 +48,7 @@ class MemberViewController: UIViewController {
 
     // MARK: - UI Properties
     
-    private lazy var navigationBar = DOONavigationBar(self, type: .backButtonWithTitle("여행 친구들"))
+    private lazy var navigationBar = DOONavigationBar(self, type: .backButtonWithTitle("함께 하는 친구들"))
     private let navigationUnderLineView: UIView = {
         let view = UIView()
         view.backgroundColor = .gray100
@@ -132,10 +132,11 @@ private extension MemberViewController {
         memeberTitleLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(24)
             $0.leading.equalToSuperview().inset(24)
+            $0.height.equalTo(ScreenUtils.getHeight(23))
         }
         
         tripFriendsCollectionView.snp.makeConstraints {
-            $0.top.equalTo(memeberTitleLabel.snp.bottom).offset(7)
+            $0.top.equalTo(memeberTitleLabel.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.height.equalTo(ScreenUtils.getHeight(67))
         }
@@ -148,7 +149,6 @@ private extension MemberViewController {
         ourTestResultView.snp.makeConstraints {
             $0.top.equalTo(ourTasteTitleLabel.snp.bottom).offset(14)
             $0.leading.trailing.equalToSuperview().inset(23)
-//            $0.height.equalTo(ScreenUtils.getHeight(505))
         }
     }
     

--- a/Going-iOS/Scene/MyProfile/ViewControllers/MyProfileViewController.swift
+++ b/Going-iOS/Scene/MyProfile/ViewControllers/MyProfileViewController.swift
@@ -169,7 +169,7 @@ private extension MyProfileViewController {
         }
         
         UIImageWriteToSavedPhotosAlbum(saveImage, self, nil, nil)
-        DOOToast.show(message: "이미지가 저장되었습니다. \n친구에게 내 캐릭터를 공유해보세요", insetFromBottom: 114)
+        DOOToast.show(message: "이미지로 저장되었어요\n친구에게 내 캐릭터를 공유해보세요", insetFromBottom: 114)
     }
     
     func showPermissionAlert() {
@@ -185,7 +185,6 @@ private extension MyProfileViewController {
             alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
             
             self.present(alert, animated: true)
-            
         }
     }
     

--- a/Going-iOS/Scene/PopUp/DeleteUserPopUp/DeleteUserPopUpViewController.swift
+++ b/Going-iOS/Scene/PopUp/DeleteUserPopUp/DeleteUserPopUpViewController.swift
@@ -43,7 +43,6 @@ final class DeleteUserPopUpViewController: PopUpDimmedViewController {
         
         setHierarchy()
         setLayout()
-        
     }
 }
 
@@ -60,11 +59,11 @@ private extension DeleteUserPopUpViewController {
             $0.center.equalToSuperview()
             $0.width.equalTo(ScreenUtils.getWidth(270))
             $0.height.equalTo(ScreenUtils.getHeight(140))
-            
         }
         
         deleteUserLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(28)
+            $0.height.equalTo(ScreenUtils.getHeight(22))
             $0.centerX.equalToSuperview()
         }
         

--- a/Going-iOS/Scene/StartTravel/ViewControllers/StartTravelSplashViewController.swift
+++ b/Going-iOS/Scene/StartTravel/ViewControllers/StartTravelSplashViewController.swift
@@ -27,13 +27,13 @@ final class StartTravelSplashViewController: UIViewController {
                                                  alignment: .center)
     
     private lazy var createTravelButton: DOOButton = {
-        let btn = DOOButton(type: .white, title: "새로운 여행 시작하기")
+        let btn = DOOButton(type: .white, title: "새로운 여행 만들기")
         btn.addTarget(self, action: #selector(createTravelButtonTapped), for: .touchUpInside)
         return btn
     }()
     
     private lazy var joinTravelButton: DOOButton = {
-        let btn = DOOButton(type: .enabled, title: "여행 입장하기")
+        let btn = DOOButton(type: .enabled, title: "초대받은 여행 입장하기")
         btn.addTarget(self, action: #selector(joinTravelButtonTapped), for: .touchUpInside)
         return btn
     }()

--- a/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
+++ b/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
@@ -971,7 +971,7 @@ extension ToDoViewController {
                 try await ToDoService.shared.deleteTodo(todoId: self.todoId)
                 self.navigationController?.popViewController(animated: true)
             }
-            DOOToast.show(message: "할 일이 삭제되었어요", insetFromBottom: ScreenUtils.getHeight(106))
+            DOOToast.show(message: "할일을 삭제했어요", insetFromBottom: ScreenUtils.getHeight(106))
         }
     }
 }

--- a/Going-iOS/Scene/UserTest/ViewControllers/UserTestViewController.swift
+++ b/Going-iOS/Scene/UserTest/ViewControllers/UserTestViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class UserTestViewController: UIViewController {
     
-    private lazy var navigationBar = DOONavigationBar(self, type: .titleLabelOnly("나의 여행 성향은?"))
+    private lazy var navigationBar = DOONavigationBar(self, type: .titleLabelOnly("나의 여행 캐릭터는?"))
     
     private var buttonIndexList: [Int] = []
     


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
#155 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 데이트피커 인디케이터 이슈 해결 
- 라이팅 전반 체크

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 바텀시트의 down 인디케이터를 통해서도
데이트피커의 날짜가 적용되도록 수정했습니다.
```swift
    /// UISwipeGestureRecognizer 연결 메서드
    @objc private func panGesture(_ recognizer: UISwipeGestureRecognizer) {
        if recognizer.state == .ended {
            switch recognizer.direction {
            case .down:
                hideBottomSheetAndGoBack()
                delegate?.didSelectDate(date: datePickerView.date)
            default:
                break
            }
        }
    }
```
- 피그마 및 기획단 더블체크로 라이팅 / 맞춤법 체크했습니다. 

## 📸 스크린샷

https://github.com/Team-Going/Going-iOS/assets/102219161/68e4d053-edcf-4099-bec3-4a319bfb2cca


## 📟 관련 이슈
- Resolved: #155
