### PR TITLE
[HOTFIX] 여행성향테스트 결과조회뷰 닉네임 서버통신 오류 수정 (#166)

### DIFF
--- a/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
+++ b/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
@@ -375,7 +375,6 @@ private extension MakeProfileViewController {
             do {
                 try await AuthService.shared.postSignUp(token: token, signUpBody: signUpBody)
                 let nextVC = UserTestSplashViewController()
-                nextVC.nickName = userName ?? ""
                 self.navigationController?.pushViewController(nextVC, animated: true)
             }
             catch {

--- a/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
+++ b/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
@@ -10,8 +10,6 @@ import UIKit
 import SnapKit
 
 final class UserTestSplashViewController: UIViewController {
-
-    var nickName: String = ""
     
     private let userTestSplashImageView: UIImageView = {
         let imageView = UIImageView()
@@ -91,7 +89,6 @@ private extension UserTestSplashViewController {
     
     @objc func nextButtonTapped() {
         let nextVC = UserTestViewController()
-        nextVC.nickName = self.nickName
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }

--- a/Going-iOS/Scene/UserTest/ViewControllers/UserTestViewController.swift
+++ b/Going-iOS/Scene/UserTest/ViewControllers/UserTestViewController.swift
@@ -10,9 +10,7 @@ import UIKit
 import SnapKit
 
 final class UserTestViewController: UIViewController {
-    
-    var nickName: String = ""
-    
+        
     private lazy var navigationBar = DOONavigationBar(self, type: .titleLabelOnly("나의 여행 캐릭터는?"))
     
     private var buttonIndexList: [Int] = []
@@ -298,7 +296,6 @@ extension UserTestViewController {
                 
                 try await OnBoardingService.shared.travelTypeTest(requestDTO: travelTypeRequsetBody)
                 let nextVC = UserTestResultViewController()
-                nextVC.nickName = self.nickName
                 self.navigationController?.pushViewController(nextVC, animated: true)
             }
             catch {

--- a/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
+++ b/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
@@ -12,8 +12,6 @@ import Photos
 
 final class UserTestResultViewController: UIViewController {
         
-    var nickName: String = ""
-
     private var testResultData: UserTypeTestResultAppData? {
         didSet {
             guard let data = testResultData else { return }
@@ -21,7 +19,7 @@ final class UserTestResultViewController: UIViewController {
             self.resultView.resultViewData = data
         }
     }
-    
+
     private var testResultIndex: Int?
     
     private lazy var navigationBar = DOONavigationBar(self, type: .titleLabelOnly("나의 여행 캐릭터"))
@@ -49,11 +47,7 @@ final class UserTestResultViewController: UIViewController {
         return imageView
     }()
     
-    private lazy var resultView: TestResultView = {
-        let view = TestResultView()
-        view.nameLabel.text = self.nickName + "님의 여행 캐릭터는"
-        return view
-    }()
+    private let resultView = TestResultView()
     
     private let gradientView =  UIView()
     
@@ -248,6 +242,7 @@ extension UserTestResultViewController {
                 let profileData = try await TravelService.shared.getProfileInfo()
                 self.testResultIndex = profileData.result
                 self.testResultData = UserTypeTestResultAppData.dummy()[profileData.result]
+                self.resultView.nameLabel.text = profileData.name + "님의 여행 캐릭터는"
             }
             catch {
                 guard let error = error as? NetworkError else { return }
@@ -280,6 +275,3 @@ extension UserTestResultViewController: TestResultViewDelegate {
         self.navigationController?.pushViewController(nextVC, animated: false)
     }
 }
-
-
-


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- #166

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 여행성향테스트 결과조회뷰 닉네임 서버통신 오류 수정
기존에 프로필조회 API의 Response를 활용하지 않고 다음 뷰컨으로 push해주는 방향으로 구현했기에
해당 데이터 사용하는 방향으로 재구현하여 오류 수정했습니다. 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src = "https://github.com/Team-Going/Going-iOS/assets/102219161/62db5f86-a84c-4bf8-886f-d2dea181befb" width ="250">|

## 📟 관련 이슈
- Resolved: #166
