### PR TITLE
[REFACTOR]코드 리팩토링 (#194)

### DIFF
--- a/Going-iOS.xcodeproj/project.pbxproj
+++ b/Going-iOS.xcodeproj/project.pbxproj
@@ -84,6 +84,10 @@
 		CA8CD69E2B47F60C00CFDFBF /* ToDoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD69D2B47F60C00CFDFBF /* ToDoViewController.swift */; };
 		CA8CD6A42B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */; };
 		CA8CD6A82B483FD000CFDFBF /* DoubleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD6A72B483FD000CFDFBF /* DoubleButtonView.swift */; };
+		CAB9A1592B60EDB800881469 /* ToDoTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB9A1582B60EDB800881469 /* ToDoTextFieldView.swift */; };
+		CAB9A15B2B60F6AE00881469 /* EndDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB9A15A2B60F6AE00881469 /* EndDateView.swift */; };
+		CAB9A15D2B60FBC700881469 /* ToDoManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB9A15C2B60FBC700881469 /* ToDoManagerView.swift */; };
+		CAB9A15F2B61002300881469 /* MemoTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB9A15E2B61002300881469 /* MemoTextView.swift */; };
 		CAC39E272B59285100B5D4A5 /* dooripsplash3.json in Resources */ = {isa = PBXBuildFile; fileRef = CAC39E262B59285100B5D4A5 /* dooripsplash3.json */; };
 		CADA02532B4AC786001FCE89 /* MyToDoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA02522B4AC786001FCE89 /* MyToDoViewController.swift */; };
 		CADA02592B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA02582B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift */; };
@@ -261,6 +265,10 @@
 		CA8CD69D2B47F60C00CFDFBF /* ToDoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoViewController.swift; sourceTree = "<group>"; };
 		CA8CD6A32B48041B00CFDFBF /* ToDoManagerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoManagerCollectionViewCell.swift; sourceTree = "<group>"; };
 		CA8CD6A72B483FD000CFDFBF /* DoubleButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleButtonView.swift; sourceTree = "<group>"; };
+		CAB9A1582B60EDB800881469 /* ToDoTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoTextFieldView.swift; sourceTree = "<group>"; };
+		CAB9A15A2B60F6AE00881469 /* EndDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndDateView.swift; sourceTree = "<group>"; };
+		CAB9A15C2B60FBC700881469 /* ToDoManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoManagerView.swift; sourceTree = "<group>"; };
+		CAB9A15E2B61002300881469 /* MemoTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoTextView.swift; sourceTree = "<group>"; };
 		CAC39E262B59285100B5D4A5 /* dooripsplash3.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = dooripsplash3.json; sourceTree = "<group>"; };
 		CADA02522B4AC786001FCE89 /* MyToDoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyToDoViewController.swift; sourceTree = "<group>"; };
 		CADA02582B4ACF4D001FCE89 /* MyToDoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyToDoCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -771,6 +779,10 @@
 			isa = PBXGroup;
 			children = (
 				CA8CD6A72B483FD000CFDFBF /* DoubleButtonView.swift */,
+				CAB9A1582B60EDB800881469 /* ToDoTextFieldView.swift */,
+				CAB9A15A2B60F6AE00881469 /* EndDateView.swift */,
+				CAB9A15C2B60FBC700881469 /* ToDoManagerView.swift */,
+				CAB9A15E2B61002300881469 /* MemoTextView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1409,6 +1421,7 @@
 				F44D98642B4EB79700341893 /* Serviceable.swift in Sources */,
 				F4C5E7842B42A6830008735F /* UILabel+.swift in Sources */,
 				F44D985A2B4E9ED400341893 /* BaseResponse.swift in Sources */,
+				CAB9A15D2B60FBC700881469 /* ToDoManagerView.swift in Sources */,
 				941B1B782B50EB0C00D28EBA /* CodeResponseDTO.swift in Sources */,
 				F430A98A2B4AD24800D482C4 /* UserTypeTestResultAppData.swift in Sources */,
 				94C7DDBA2B4C77FF00541567 /* SettingsItem.swift in Sources */,
@@ -1417,6 +1430,7 @@
 				F4BEB4CF2B4838B60074B1B2 /* TestResultTicketView.swift in Sources */,
 				CA8CD6872B46B85A00CFDFBF /* UnderlineSegmentedControlView.swift in Sources */,
 				CA3EEE312B4D9A2500C23A41 /* TabBarView.swift in Sources */,
+				CAB9A15B2B60F6AE00881469 /* EndDateView.swift in Sources */,
 				F4BA26FA2B47198D00975CC2 /* ScreenUtils.swift in Sources */,
 				F4BEB4C02B480DAE0074B1B2 /* DOOLabel.swift in Sources */,
 				F44D98702B4ECB2200341893 /* DataTypeProtocol.swift in Sources */,
@@ -1508,6 +1522,7 @@
 				F4015E2B2B5424F0006709F4 /* UserIdDefault.swift in Sources */,
 				F4BA26F22B42D07000975CC2 /* PersonalInfoWebViewController.swift in Sources */,
 				CA8CD6832B46B72E00CFDFBF /* TripMiddleView.swift in Sources */,
+				CAB9A15F2B61002300881469 /* MemoTextView.swift in Sources */,
 				F45CA15C2B51868C00F3790C /* NetworkErrorCode.swift in Sources */,
 				F444610B2B4D8EDE00674D74 /* DOOPopUpContainerView.swift in Sources */,
 				F4BEB4CD2B4833D30074B1B2 /* TestResultView.swift in Sources */,
@@ -1524,6 +1539,7 @@
 				945D1AD92B544E0D00C728E2 /* MemberTestStruct.swift in Sources */,
 				F4FE6BA52B50B401009C935E /* IsAppleLogined.swift in Sources */,
 				F485D48F2B47CF9B007317F4 /* UserTestViewController.swift in Sources */,
+				CAB9A1592B60EDB800881469 /* ToDoTextFieldView.swift in Sources */,
 				F4FE6B872B504C8C009C935E /* AuthService.swift in Sources */,
 				F45CA1652B53063600F3790C /* TravelTypeTestRequestDTO.swift in Sources */,
 				F44461062B4D7F1100674D74 /* UIWindow+.swift in Sources */,

--- a/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
@@ -53,14 +53,22 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
         view.backgroundColor = UIColor.gray50
         return view
     }()
-    lazy var todoTitleLabel: UILabel = DOOLabel(font: .pretendard(.body3_medi), color: .gray700, alignment: .left)
-    private let deadlineLabel: UILabel = DOOLabel(font: .pretendard(.detail3_regular), color: .gray300, alignment: .center)
+    private let todoTitleLabel = DOOLabel(
+        font: .pretendard(.body3_medi),
+        color: .gray700,
+        alignment: .left
+    )
+    private let deadlineLabel = DOOLabel(
+        font: .pretendard(.detail3_regular),
+        color: .gray300,
+        alignment: .center
+    )
 
     private let  managerCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clear
+        collectionView.backgroundColor = .gray50
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.showsVerticalScrollIndicator = false
         collectionView.isScrollEnabled = false
@@ -82,7 +90,6 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
         setHierachy()
         registerCell()
         setLayout()
-        setStyle()
         setDelegate()
     }
     
@@ -95,7 +102,6 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
         let index = self.index ?? 0
         let image = self.checkButton.imageView?.image ?? UIImage()
         self.delegate?.getButtonIndex(index: index, image: image)
-
     }
 }
 
@@ -105,7 +111,12 @@ private extension MyToDoCollectionViewCell {
     
     func setHierachy() {
         contentView.addSubview(todoBackgroundView)
-        todoBackgroundView.addSubviews(checkButton, todoTitleLabel, managerCollectionView, deadlineLabel)
+        todoBackgroundView.addSubviews(
+            checkButton,
+            todoTitleLabel,
+            managerCollectionView,
+            deadlineLabel
+        )
     }
     
     func setLayout() {
@@ -133,26 +144,6 @@ private extension MyToDoCollectionViewCell {
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))
         }
     }
-    
-    func setStyle() {
-        managerCollectionView.backgroundColor = .gray50
-    }
-    
-    func setManagerLabel(label: UILabel, text: String) {
-        label.text = text
-        label.font = UIFont.systemFont(ofSize: 10, weight: .semibold)
-        label.textColor = .white
-        label.backgroundColor = .black
-        label.layer.cornerRadius = 5
-    }
-    func setCollectionView() -> UICollectionView {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-        collectionView.backgroundColor = .clear
-        collectionView.showsVerticalScrollIndicator = false
-        collectionView.isScrollEnabled = false
-        return collectionView
-    }
-    
 
     func setDelegate() {
         self.managerCollectionView.dataSource = self

--- a/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
@@ -9,8 +9,11 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
     // MARK: - Properties
     
     static let identifier = "MyToDoCollectionViewCell"
+    
     weak var delegate: MyToDoCollectionViewDelegate?
+    
     var manager: [Allocators] = []
+    
     var myToDoData: ToDoAppData? {
         didSet {
             guard let myToDoData else {return}
@@ -19,6 +22,7 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
             self.manager = myToDoData.allocators
         }
     }
+    
     var index: Int? {
         didSet {
             guard let index else {return}
@@ -26,12 +30,14 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
             self.managerCollectionView.reloadData()
         }
     }
+    
     var textColor: UIColor? {
         didSet {
             guard let textColor else {return}
             self.todoTitleLabel.textColor = textColor
         }
     }
+    
     var buttonImg: UIImage? {
         didSet {
             guard let buttonImg else {return}
@@ -39,11 +45,13 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
             self.managerCollectionView.reloadData()
         }
     }
+    
     var isComplete: Bool? {
         didSet {
             self.managerCollectionView.reloadData()
         }
     }
+    
     
     // MARK: - UI Components
     
@@ -53,11 +61,13 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
         view.backgroundColor = UIColor.gray50
         return view
     }()
+    
     private let todoTitleLabel = DOOLabel(
         font: .pretendard(.body3_medi),
         color: .gray700,
         alignment: .left
     )
+    
     private let deadlineLabel = DOOLabel(
         font: .pretendard(.detail3_regular),
         color: .gray300,
@@ -105,6 +115,7 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
     }
 }
 
+
 // MARK: - Private Method
 
 private extension MyToDoCollectionViewCell {
@@ -124,21 +135,25 @@ private extension MyToDoCollectionViewCell {
             $0.leading.trailing.equalToSuperview()
             $0.top.bottom.equalToSuperview()
         }
+        
         checkButton.snp.makeConstraints{
             $0.top.equalToSuperview().inset(ScreenUtils.getHeight(16))
             $0.leading.equalToSuperview().inset(ScreenUtils.getWidth(12))
             $0.size.equalTo(ScreenUtils.getHeight(20))
         }
+        
         todoTitleLabel.snp.makeConstraints{
             $0.top.equalToSuperview().inset(ScreenUtils.getWidth(16))
             $0.leading.equalTo(checkButton.snp.trailing).offset(ScreenUtils.getWidth(12))
         }
+        
         managerCollectionView.snp.makeConstraints{
             $0.leading.equalTo(checkButton.snp.trailing).offset(ScreenUtils.getWidth(12))
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))
             $0.bottom.equalToSuperview().inset(ScreenUtils.getHeight(15))
             $0.height.equalTo(ScreenUtils.getHeight(20))
         }
+        
         deadlineLabel.snp.makeConstraints{
             $0.top.equalToSuperview().inset(ScreenUtils.getHeight(16))
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))
@@ -177,8 +192,8 @@ extension MyToDoCollectionViewCell: UICollectionViewDataSource{
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-
         guard let managerCell = collectionView.dequeueReusableCell(withReuseIdentifier: ManagerCollectionViewCell.identifier, for: indexPath) as? ManagerCollectionViewCell else {return UICollectionViewCell()}
+        
         let data = self.myToDoData ?? ToDoAppData(todoId: 0, title: "", endDate: "", allocators: [], secret: false)
         
         if data.secret {

--- a/Going-iOS/Scene/MyToDo/ViewControllers/MyToDoViewController.swift
+++ b/Going-iOS/Scene/MyToDo/ViewControllers/MyToDoViewController.swift
@@ -7,8 +7,11 @@ final class MyToDoViewController: UIViewController {
     // MARK: - UI Property
 
     private lazy var contentView: UIView = UIView()
+    
     private lazy var navigationBarview = DOONavigationBar(self, type: .myToDo, backgroundColor: .gray50)
+    
     private let tripHeaderView = TripHeaderView()
+    
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .white000
@@ -16,6 +19,7 @@ final class MyToDoViewController: UIViewController {
         scrollView.isScrollEnabled = true
         return scrollView
     }()
+    
     private lazy var myToDoCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
@@ -28,11 +32,13 @@ final class MyToDoViewController: UIViewController {
         collectionView.isScrollEnabled = false
         return collectionView
     }()
+    
     private lazy var myToDoHeaderView: OurToDoHeaderView = {
         let header = OurToDoHeaderView()
         header.segmentedControl.addTarget(self, action: #selector(didChangeValue(sender: )), for: .valueChanged)
         return header
     }()
+    
     private lazy var stickyMyToDoHeaderView: OurToDoHeaderView = {
         let headerView = OurToDoHeaderView()
         headerView.isHidden = true
@@ -40,6 +46,7 @@ final class MyToDoViewController: UIViewController {
         headerView.segmentedControl.addTarget(self, action: #selector(didChangeValue(sender: )), for: .valueChanged)
         return headerView
     }()
+    
     private lazy var addToDoButton: UIButton = {
         let btn = UIButton()
         btn.backgroundColor = .red700
@@ -54,35 +61,48 @@ final class MyToDoViewController: UIViewController {
         btn.layer.cornerRadius = ScreenUtils.getHeight(26)
         return btn
     }()
+    
     private let emptyView: UIView = UIView()
+    
     private let emptyViewIcon: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.MyToDo.emptyViewIcon
         imageView.tintColor = .gray100
         return imageView
     }()
+    
     private let emptyViewLabel: UILabel = DOOLabel(
         font: .pretendard(.body3_medi),
         color: .gray200,
         text: StringLiterals.OurToDo.pleaseAddToDo,
         alignment: .center
     )
+    
     private let myToDoMainImageView: UIImageView = {
         let imgView = UIImageView()
         imgView.image = ImageLiterals.MyToDo.mainViewIcon
         return imgView
     }()
     
+    
     // MARK: - Properties
     
     var myId: Int = 0
+    
     var tripId: Int = 0
+    
     var segmentIndex: Int = 0
+    
     var initializeCode: Bool = false
+    
     private var index: Int = 0
+    
     private var todoId: Int = 0
+    
     private var progress: String = "incomplete"
+    
     private var isSetDashBoardRoot: Bool = false
+    
     private var headerData: MyToDoHeaderAppData? {
         didSet {
             guard let data = headerData else { return }
@@ -97,6 +117,7 @@ final class MyToDoViewController: UIViewController {
             self.tripHeaderView.tripDdayLabel.attributedText = firstString
         }
     }
+    
     private var myToDoData: [ToDoAppData]? {
         didSet {
             Task {
@@ -150,13 +171,11 @@ private extension MyToDoViewController {
     func setHierachy() {
         self.view.addSubviews(navigationBarview, scrollView, addToDoButton)
         scrollView.addSubviews(contentView, stickyMyToDoHeaderView)
-        contentView.addSubviews(
-            tripHeaderView,
-            myToDoMainImageView,
-            myToDoHeaderView,
-            myToDoCollectionView,
-            emptyView
-        )
+        contentView.addSubviews(tripHeaderView,
+                                myToDoMainImageView,
+                                myToDoHeaderView,
+                                myToDoCollectionView,
+                                emptyView)
         emptyView.addSubviews(emptyViewIcon, emptyViewLabel)
     }
     
@@ -166,55 +185,66 @@ private extension MyToDoViewController {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(50))
         }
+        
         scrollView.snp.makeConstraints{
             $0.top.equalTo(navigationBarview.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview().inset(ScreenUtils.getHeight(90))
         }
+        
         contentView.snp.makeConstraints{
             $0.height.greaterThanOrEqualTo(myToDoCollectionView.contentSize.height)
             $0.edges.width.equalTo(scrollView.contentLayoutGuide)
         }
+        
         tripHeaderView.snp.makeConstraints{
             $0.leading.trailing.equalToSuperview()
             $0.top.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(102))
         }
+        
         myToDoMainImageView.snp.makeConstraints {
             $0.top.equalTo(tripHeaderView)
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))
             $0.width.equalTo(ScreenUtils.getWidth(137))
             $0.height.equalTo(ScreenUtils.getHeight(100))
         }
+        
         myToDoHeaderView.snp.makeConstraints{
             $0.top.equalTo(tripHeaderView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(49))
         }
+        
         emptyView.snp.remakeConstraints {
             $0.top.equalTo(myToDoHeaderView.snp.bottom)
             $0.bottom.equalTo(contentView)
             $0.leading.trailing.equalToSuperview()
         }
+        
         emptyViewIcon.snp.makeConstraints {
             $0.top.equalToSuperview().inset(ScreenUtils.getHeight(150))
             $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(114))
         }
+        
         emptyViewLabel.snp.makeConstraints {
             $0.top.equalTo(emptyViewIcon.snp.bottom).offset(ScreenUtils.getHeight(16))
             $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(129))
         }
+        
         myToDoCollectionView.snp.makeConstraints {
             $0.top.equalTo(myToDoHeaderView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(contentView)
             $0.height.equalTo(myToDoCollectionView.contentSize.height)
-            }
+        }
+        
         stickyMyToDoHeaderView.snp.makeConstraints{
             $0.top.equalTo(navigationBarview.snp.bottom)
             $0.leading.trailing.width.equalTo(scrollView)
             $0.height.equalTo(ScreenUtils.getHeight(49))
         }
+        
         addToDoButton.snp.makeConstraints{
             $0.width.equalTo(ScreenUtils.getWidth(117))
             $0.height.equalTo(ScreenUtils.getHeight(50))

--- a/Going-iOS/Scene/MyToDo/ViewControllers/MyToDoViewController.swift
+++ b/Going-iOS/Scene/MyToDo/ViewControllers/MyToDoViewController.swift
@@ -21,11 +21,7 @@ final class MyToDoViewController: UIViewController {
     }()
     
     private lazy var myToDoCollectionView: UICollectionView = {
-        let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.scrollDirection = .vertical
-        flowLayout.itemSize = CGSize(width: ScreenUtils.getWidth(327) , height: ScreenUtils.getHeight(81))
-        flowLayout.sectionInset = UIEdgeInsets(top: ScreenUtils.getHeight(12), left: 1.0, bottom: 1.0, right: 1.0)
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collectionView.backgroundColor = .white000
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
@@ -439,6 +435,17 @@ extension MyToDoViewController: UICollectionViewDataSource{
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         self.todoId = self.myToDoData?[indexPath.row].todoId ?? 0
         setToDoView(before: "my", naviBarTitle: StringLiterals.ToDo.inquiry, isActivate: false)
+    }
+}
+
+extension MyToDoViewController: UICollectionViewDelegateFlowLayout {
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return  UIEdgeInsets(top: ScreenUtils.getHeight(18), left: 1.0, bottom: 1.0, right: 1.0)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: ScreenUtils.getWidth(331) , height: ScreenUtils.getHeight(81))
     }
 }
 

--- a/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
@@ -53,7 +53,17 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
         alignment: .center
     )
     lazy var managerCollectionView: UICollectionView = {
-        setCollectionView()
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .horizontal
+        flowLayout.minimumInteritemSpacing = ScreenUtils.getWidth(4)
+        flowLayout.minimumLineSpacing = ScreenUtils.getWidth(4)
+        flowLayout.itemSize = CGSize(width: ScreenUtils.getWidth(42) , height: ScreenUtils.getHeight(20))
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.isScrollEnabled = false
+        collectionView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapManagerCollectionView(_:))))
+        return collectionView
     }()
 
     
@@ -117,24 +127,6 @@ private extension OurToDoCollectionViewCell {
         label.textColor = textColor
         label.textAlignment = alignment
         return label
-    }
-    
-    func setCollectionView() -> UICollectionView {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: setCollectionViewLayout())
-        collectionView.backgroundColor = .clear
-        collectionView.showsVerticalScrollIndicator = false
-        collectionView.isScrollEnabled = false
-        collectionView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapManagerCollectionView(_:))))
-        return collectionView
-    }
-    
-    func setCollectionViewLayout() -> UICollectionViewFlowLayout {
-        let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.scrollDirection = .horizontal
-        flowLayout.minimumInteritemSpacing = ScreenUtils.getWidth(4)
-        flowLayout.minimumLineSpacing = ScreenUtils.getWidth(4)
-        flowLayout.itemSize = CGSize(width: ScreenUtils.getWidth(42) , height: ScreenUtils.getHeight(20))
-        return flowLayout
     }
     
     func setDelegate() {

--- a/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
@@ -20,6 +20,7 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
             self.managerCollectionView.reloadData()
         }
     }
+   
     var index: Int? {
         didSet {
             guard let index else {return}
@@ -42,16 +43,19 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
         view.backgroundColor = UIColor.gray50
         return view
     }()
+    
     let todoTitleLabel: UILabel = DOOLabel(
         font: .pretendard(.body3_medi),
         color: .gray700,
         alignment: .left
     )
+   
     private lazy var deadlineLabel: UILabel = DOOLabel(
         font: .pretendard(.detail3_regular),
         color: .gray300,
         alignment: .center
     )
+    
     lazy var managerCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal

--- a/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
@@ -59,9 +59,6 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
     lazy var managerCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
-        flowLayout.minimumInteritemSpacing = ScreenUtils.getWidth(4)
-        flowLayout.minimumLineSpacing = ScreenUtils.getWidth(4)
-        flowLayout.itemSize = CGSize(width: ScreenUtils.getWidth(42) , height: ScreenUtils.getHeight(20))
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         collectionView.backgroundColor = .clear
         collectionView.showsVerticalScrollIndicator = false
@@ -170,5 +167,20 @@ extension OurToDoCollectionViewCell: UICollectionViewDataSource {
             }
         }
         return managerCell
+    }
+}
+
+extension OurToDoCollectionViewCell: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return ScreenUtils.getWidth(4)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return ScreenUtils.getWidth(4)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: ScreenUtils.getWidth(42) , height: ScreenUtils.getHeight(20))
     }
 }

--- a/Going-iOS/Scene/OurToDo/Cells/TripFriendsCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/TripFriendsCollectionViewCell.swift
@@ -25,6 +25,7 @@ class TripFriendsCollectionViewCell: UICollectionViewCell {
         imageView.layer.masksToBounds = true
         return imageView
     }()
+    
     var friendNameLabel: UILabel = DOOLabel(
         font: .pretendard(.detail3_regular),
         color: .gray500,

--- a/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
+++ b/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
@@ -25,7 +25,18 @@ final class OurToDoViewController: UIViewController {
         headerView.backgroundColor = .white000
         return headerView
     }()
-    private lazy var ourToDoCollectionView: UICollectionView = {setCollectionView()}()
+    private lazy var ourToDoCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .vertical
+        flowLayout.itemSize = CGSize(width: ScreenUtils.getWidth(331) , height: ScreenUtils.getHeight(81))
+        flowLayout.sectionInset = UIEdgeInsets(top: ScreenUtils.getHeight(18), left: 1.0, bottom: 1.0, right: 1.0)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.backgroundColor = .white000
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.isScrollEnabled = false
+        return collectionView
+    }()
     private lazy var addToDoButton: UIButton = {
         let btn = UIButton()
         btn.backgroundColor = .red700
@@ -40,12 +51,7 @@ final class OurToDoViewController: UIViewController {
         btn.layer.cornerRadius = ScreenUtils.getHeight(26)
         return btn
     }()
-    
-    private let emptyView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .black
-        return view
-    }()
+    private let emptyView: UIView = UIView()
     private let emptyViewIconImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.OurToDo.emptyViewIcon
@@ -58,7 +64,6 @@ final class OurToDoViewController: UIViewController {
         text: StringLiterals.OurToDo.pleaseAddToDo,
         alignment: .center
     )
-    
     private let ourToDoMainImageView: UIImageView = {
         let imgView = UIImageView()
         imgView.image = ImageLiterals.OurToDo.mainViewIcon
@@ -67,17 +72,15 @@ final class OurToDoViewController: UIViewController {
     
     
     // MARK: - Property
-    
-    private var isSetDashBoardRoot: Bool = false
-    
-    var initializeCode: Bool = false
-
+        
     var tripId: Int = 0
-    
+    var todoId: Int = 0
     var segmentIndex: Int = 0
-    
+    var allocator: [Allocators] = []
+    var initializeCode: Bool = false
     var progress: String = "incomplete"
-    
+    private var inviteCode: String?
+    private var isSetDashBoardRoot: Bool = false
     private var headerData: OurToDoHeaderAppData? {
         didSet {
             guard let data = headerData else { return }
@@ -88,25 +91,16 @@ final class OurToDoViewController: UIViewController {
             self.tripMiddleView.progress = data.progress
         }
     }
-    
-    private var inviteCode: String?
-    
-    var todoId: Int = 0
-    
-    var ourToDoData: [ToDoAppData]? {
+    private var ourToDoData: [ToDoAppData]? {
         didSet {
             Task {
                 ourToDoCollectionView.reloadData()
                 await loadData()
-
             }
             getOurToDoHeaderData()
         }
     }
-    
-    var allocator: [Allocators] = []
-    
-    var detailToDoData: DetailToDoAppData = DetailToDoAppData(title: "", endDate: "", allocators: [], memo: "", secret: false)
+        
     
     // MARK: - Life Cycle
     
@@ -129,9 +123,7 @@ final class OurToDoViewController: UIViewController {
         Task {
             await loadData()
         }
-        
         self.navigationBarview.backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
-
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -169,7 +161,6 @@ private extension OurToDoViewController {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(50))
         }
-        
         scrollView.snp.makeConstraints{
             $0.top.equalTo(navigationBarview.snp.bottom)
             $0.leading.trailing.equalToSuperview()
@@ -242,7 +233,6 @@ private extension OurToDoViewController {
         } else {
             self.navigationController?.popViewController(animated: true)
         }
-      
     }
     
     func loadData() async {
@@ -273,23 +263,6 @@ private extension OurToDoViewController {
         stickyOurToDoHeaderView.segmentedControl.addTarget(self, action: #selector(didChangeValue(segment:)), for: .valueChanged)
     }
     
-    func setCollectionView() -> UICollectionView {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: setCollectionViewLayout())
-        collectionView.backgroundColor = .white000
-        collectionView.showsVerticalScrollIndicator = false
-        collectionView.showsHorizontalScrollIndicator = false
-        collectionView.isScrollEnabled = false
-        return collectionView
-    }
-    
-    func setCollectionViewLayout() -> UICollectionViewFlowLayout {
-        let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.scrollDirection = .vertical
-        flowLayout.itemSize = CGSize(width: ScreenUtils.getWidth(331) , height: ScreenUtils.getHeight(81))
-        flowLayout.sectionInset = UIEdgeInsets(top: ScreenUtils.getHeight(18), left: 1.0, bottom: 1.0, right: 1.0)
-        return flowLayout
-    }
-    
     func registerCell() {
         self.ourToDoCollectionView.register(OurToDoCollectionViewCell.self, forCellWithReuseIdentifier: OurToDoCollectionViewCell.identifier)
     }
@@ -309,9 +282,7 @@ private extension OurToDoViewController {
         todoVC.tripId = self.tripId
         todoVC.beforeVC = before
         todoVC.fromOurTodoParticipants = header.participants
-        
         todoVC.manager = self.allocator
-        
         todoVC.isActivateView = isActivate
         todoVC.todoId = self.todoId
         self.navigationController?.pushViewController(todoVC, animated: false)

--- a/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
+++ b/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
@@ -7,10 +7,15 @@ final class OurToDoViewController: UIViewController {
     // MARK: - UI Property
     
     private lazy var contentView: UIView = UIView()
+   
     private lazy var navigationBarview = DOONavigationBar(self, type: .ourToDo, backgroundColor: .gray50)
+    
     private let tripHeaderView: TripHeaderView = TripHeaderView()
+    
     private let tripMiddleView: TripMiddleView = TripMiddleView()
+    
     private let ourToDoHeaderView: OurToDoHeaderView = OurToDoHeaderView()
+    
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .white000
@@ -19,12 +24,14 @@ final class OurToDoViewController: UIViewController {
         scrollView.isScrollEnabled = true
         return scrollView
     }()
+    
     private let stickyOurToDoHeaderView: OurToDoHeaderView = {
         let headerView = OurToDoHeaderView()
         headerView.isHidden = true
         headerView.backgroundColor = .white000
         return headerView
     }()
+    
     private lazy var ourToDoCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
@@ -37,6 +44,7 @@ final class OurToDoViewController: UIViewController {
         collectionView.isScrollEnabled = false
         return collectionView
     }()
+    
     private lazy var addToDoButton: UIButton = {
         let btn = UIButton()
         btn.backgroundColor = .red700
@@ -51,19 +59,23 @@ final class OurToDoViewController: UIViewController {
         btn.layer.cornerRadius = ScreenUtils.getHeight(26)
         return btn
     }()
+    
     private let emptyView: UIView = UIView()
+    
     private let emptyViewIconImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.OurToDo.emptyViewIcon
         imageView.tintColor = .gray100
         return imageView
     }()
+    
     private let emptyViewLabel: UILabel = DOOLabel(
         font: .pretendard(.body3_medi),
         color: .gray200,
         text: StringLiterals.OurToDo.pleaseAddToDo,
         alignment: .center
     )
+    
     private let ourToDoMainImageView: UIImageView = {
         let imgView = UIImageView()
         imgView.image = ImageLiterals.OurToDo.mainViewIcon
@@ -74,13 +86,21 @@ final class OurToDoViewController: UIViewController {
     // MARK: - Property
         
     var tripId: Int = 0
+    
     var todoId: Int = 0
+    
     var segmentIndex: Int = 0
+    
     var allocator: [Allocators] = []
+    
     var initializeCode: Bool = false
+    
     var progress: String = "incomplete"
+    
     private var inviteCode: String?
+    
     private var isSetDashBoardRoot: Bool = false
+    
     private var headerData: OurToDoHeaderAppData? {
         didSet {
             guard let data = headerData else { return }
@@ -91,6 +111,7 @@ final class OurToDoViewController: UIViewController {
             self.tripMiddleView.progress = data.progress
         }
     }
+    
     private var ourToDoData: [ToDoAppData]? {
         didSet {
             Task {
@@ -151,7 +172,12 @@ private extension OurToDoViewController {
     func setHierarchy() {
         self.view.addSubviews(navigationBarview, scrollView, addToDoButton)
         scrollView.addSubviews(contentView, stickyOurToDoHeaderView)
-        contentView.addSubviews(tripHeaderView, tripMiddleView, ourToDoMainImageView, ourToDoHeaderView, ourToDoCollectionView, emptyView)
+        contentView.addSubviews(tripHeaderView, 
+                                tripMiddleView,
+                                ourToDoMainImageView,
+                                ourToDoHeaderView,
+                                ourToDoCollectionView,
+                                emptyView)
         emptyView.addSubviews(emptyViewIconImageView, emptyViewLabel)
     }
     
@@ -161,61 +187,73 @@ private extension OurToDoViewController {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(50))
         }
+        
         scrollView.snp.makeConstraints{
             $0.top.equalTo(navigationBarview.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview().inset(ScreenUtils.getHeight(90))
         }
+        
         contentView.snp.makeConstraints{
             $0.height.greaterThanOrEqualTo(ourToDoCollectionView.contentSize.height).priority(.low)
             $0.edges.width.equalTo(scrollView)
         }
+        
         tripHeaderView.snp.makeConstraints{
             $0.leading.trailing.equalToSuperview()
             $0.top.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(102))
         }
+        
         tripMiddleView.snp.makeConstraints{
             $0.top.equalTo(tripHeaderView.snp.bottom).offset(ScreenUtils.getHeight(20))
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(235))
         }
+        
         ourToDoMainImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.trailing.equalToSuperview()
             $0.width.equalTo(ScreenUtils.getWidth(112))
             $0.height.equalTo(ScreenUtils.getHeight(135))
         }
+        
         ourToDoHeaderView.snp.makeConstraints{
             $0.top.equalTo(tripMiddleView.snp.bottom).offset(ScreenUtils.getHeight(28))
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(49))
         }
+        
         emptyView.snp.makeConstraints {
             $0.top.equalTo(ourToDoHeaderView.snp.bottom)
             $0.bottom.equalTo(contentView)
             $0.leading.trailing.equalToSuperview()
         }
+        
         emptyViewIconImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(ScreenUtils.getHeight(30))
             $0.leading.equalToSuperview().inset(ScreenUtils.getWidth(108))
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(95))
         }
+        
         emptyViewLabel.snp.makeConstraints {
             $0.top.equalTo(emptyViewIconImageView.snp.bottom).offset(ScreenUtils.getHeight(8))
             $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(129))
         }
+        
         ourToDoCollectionView.snp.makeConstraints {
             $0.top.equalTo(ourToDoHeaderView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(contentView)
             $0.height.equalTo(ourToDoCollectionView.contentSize.height).priority(.low)
          }
+        
         stickyOurToDoHeaderView.snp.makeConstraints{
             $0.top.equalTo(navigationBarview.snp.bottom)
             $0.leading.trailing.width.equalTo(scrollView)
             $0.height.equalTo(ScreenUtils.getHeight(49))
         }
+        
         addToDoButton.snp.makeConstraints{
             $0.width.equalTo(ScreenUtils.getWidth(117))
             $0.height.equalTo(ScreenUtils.getHeight(50))
@@ -306,13 +344,7 @@ private extension OurToDoViewController {
     // MARK: - objc method
     
     @objc
-    func popToDashBoardView(_ sender: UITapGestureRecognizer) {
-        print("popToDashBoardView")
-    }
-    
-    @objc
     func pushToAddToDoView() {
-        
         setToDoView(before: "our" , naviBarTitle: "추가", isActivate: true)
     }
     

--- a/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
+++ b/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
@@ -33,11 +33,7 @@ final class OurToDoViewController: UIViewController {
     }()
     
     private lazy var ourToDoCollectionView: UICollectionView = {
-        let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.scrollDirection = .vertical
-        flowLayout.itemSize = CGSize(width: ScreenUtils.getWidth(331) , height: ScreenUtils.getHeight(81))
-        flowLayout.sectionInset = UIEdgeInsets(top: ScreenUtils.getHeight(18), left: 1.0, bottom: 1.0, right: 1.0)
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collectionView.backgroundColor = .white000
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
@@ -441,6 +437,17 @@ extension OurToDoViewController: UICollectionViewDataSource {
         self.todoId = self.ourToDoData?[indexPath.row].todoId ?? 0
         self.allocator =  self.ourToDoData?[indexPath.row].allocators ?? []
         setToDoView(before: "our", naviBarTitle: StringLiterals.ToDo.inquiry, isActivate: false)
+    }
+}
+
+extension OurToDoViewController: UICollectionViewDelegateFlowLayout {
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return  UIEdgeInsets(top: ScreenUtils.getHeight(18), left: 1.0, bottom: 1.0, right: 1.0)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: ScreenUtils.getWidth(331) , height: ScreenUtils.getHeight(81))
     }
 }
 

--- a/Going-iOS/Scene/OurToDo/Views/OurToDoHeaderView.swift
+++ b/Going-iOS/Scene/OurToDo/Views/OurToDoHeaderView.swift
@@ -21,6 +21,7 @@ final class OurToDoHeaderView: UIView {
         segmentedControl.selectedSegmentIndex = 0
         return segmentedControl
     }()
+    
     private let underlineView: UIView = UIView()
 
     
@@ -52,6 +53,7 @@ private extension OurToDoHeaderView {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.height.equalTo(1)
         }
+        
         segmentedControl.snp.makeConstraints{
             $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview()

--- a/Going-iOS/Scene/OurToDo/Views/TripHeaderView.swift
+++ b/Going-iOS/Scene/OurToDo/Views/TripHeaderView.swift
@@ -16,26 +16,32 @@ final class TripHeaderView: UIView {
         stackView.spacing = 8
         return stackView
     }()
+    
     lazy var tripNameLabel: UILabel = DOOLabel(
         font: .pretendard(.head2),
         color: .gray700,
         alignment: .left
     )
+    
     lazy var tripDdayLabel: UILabel = DOOLabel(
         font: .pretendard(.head2),
         color: .gray700,
         alignment: .left
     )
+    
     lazy var tripDateLabel: UILabel = DOOLabel(
         font: .pretendard(.body3_medi),
         color: .gray300,
         alignment: .left
     )
+    
     let tripDateLabelAttachImg: NSTextAttachment = NSTextAttachment(image: ImageLiterals.OurToDo.icCalendar)
-    private var dDay: Int = 0
+    
     
     // MARK: - Property
     
+    private var dDay: Int = 0
+
     var tripData: OurToDoHeaderAppData? {
         didSet {
             guard let data = tripData else {return}
@@ -141,6 +147,7 @@ private extension TripHeaderView {
             $0.top.equalToSuperview()
             $0.height.equalToSuperview()
         }
+        
         tripDateLabel.snp.makeConstraints{
             $0.height.equalTo(ScreenUtils.getHeight(21))
         }

--- a/Going-iOS/Scene/OurToDo/Views/TripHeaderView.swift
+++ b/Going-iOS/Scene/OurToDo/Views/TripHeaderView.swift
@@ -84,7 +84,6 @@ final class TripHeaderView: UIView {
             
             self.tripDateLabel.text = newStartDate + " - " + newEndDate
             
-            
             let string = self.tripDateLabel.text ?? ""
             let date = NSAttributedString(string: " \(string)" )
             let attachImg = NSAttributedString(attachment: tripDateLabelAttachImg)

--- a/Going-iOS/Scene/OurToDo/Views/TripMiddleView.swift
+++ b/Going-iOS/Scene/OurToDo/Views/TripMiddleView.swift
@@ -24,17 +24,20 @@ final class TripMiddleView: UIView {
         imgView.isUserInteractionEnabled = true
         return imgView
     }()
+    
     private lazy var tripProgressLabel: UILabel = DOOLabel(
         font: .pretendard(.body2_medi),
         color: .gray700,
         text: StringLiterals.OurToDo.ourProgress,
         alignment: .left
     )
+    
     private lazy var percentageLabel: UILabel = DOOLabel(
         font: .pretendard(.body2_medi),
         color: .red400,
         alignment: .right
     )
+    
     private var tripProgressBar: UIProgressView = {
         let progressBar = UIProgressView()
         progressBar.trackTintColor = UIColor.gray100
@@ -51,17 +54,20 @@ final class TripMiddleView: UIView {
         view.addGestureRecognizer(friendsLabelTapGestureRecognizer)
         return view
     }()
+    
     private let tripFriendsLabel: DOOLabel = DOOLabel(
         font: .pretendard(.body2_medi),
         color: .gray700,
         text: StringLiterals.OurToDo.friends,
         alignment: .left
     )
+   
     private lazy var tripFriendsBtn: UIButton = {
         let btn = UIButton()
         btn.addTarget(self, action: #selector(pushToInquiryFriendsView), for: .touchUpInside)
         return btn
     }()
+   
     private lazy var tripFriendsCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
@@ -72,6 +78,7 @@ final class TripMiddleView: UIView {
         collectionView.isScrollEnabled = true
         return collectionView
     }()
+   
     private lazy var addButton: UIButton = {
         let btn = UIButton()
         btn.backgroundColor = .gray50
@@ -81,13 +88,16 @@ final class TripMiddleView: UIView {
         btn.addTarget(self, action: #selector(pushToAddFriendsView), for: .touchUpInside)
         return btn
     }()
+    
     private lazy var addLabel: UILabel = DOOLabel(
         font: .pretendard(.detail3_regular),
         color: .gray500,
         text: StringLiterals.OurToDo.invite,
         alignment: .center
     )
+   
     var gradientView: UIView = UIView()
+    
     var addStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -100,8 +110,11 @@ final class TripMiddleView: UIView {
     // MARK: - Property
     
     private var userType: Int = 0
+    
     var friendProfile: [Participant] = []
+    
     weak var delegate: TripMiddleViewDelegate?
+    
     var progress: Int? {
         didSet {
             guard let progress else {return}
@@ -109,6 +122,7 @@ final class TripMiddleView: UIView {
             self.tripProgressBar.progress = Float(progress) * 0.01
         }
     }
+    
     var participants: [Participant]? {
         didSet {
             guard let participants else {return}
@@ -116,6 +130,7 @@ final class TripMiddleView: UIView {
             self.tripFriendsCollectionView.reloadData()
         }
     }
+  
     
     // MARK: - Life Cycle
     
@@ -172,30 +187,36 @@ private extension TripMiddleView {
             $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(24))
             $0.top.bottom.equalToSuperview()
         }
+        
         tripProgressLabel.snp.makeConstraints{
             $0.top.equalToSuperview().inset(ScreenUtils.getHeight(20))
             $0.leading.equalToSuperview().inset(ScreenUtils.getWidth(16))
             $0.width.equalTo(ScreenUtils.getWidth(100))
         }
+        
         percentageLabel.snp.makeConstraints{
             $0.top.equalToSuperview().inset(ScreenUtils.getHeight(20))
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))
         }
+        
         tripProgressBar.snp.makeConstraints{
             $0.top.equalTo(tripProgressLabel.snp.bottom).offset(ScreenUtils.getHeight(12))
             $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))
             $0.height.equalTo(ScreenUtils.getHeight(10))
         }
+        
         tripFriendsContainer.snp.makeConstraints{
             $0.top.equalTo(tripProgressBar.snp.bottom).offset(ScreenUtils.getHeight(52))
             $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))
             $0.height.equalTo(ScreenUtils.getHeight(23))
         }
+        
         tripFriendsLabel.snp.makeConstraints{
             $0.top.bottom.equalToSuperview()
             $0.leading.equalToSuperview()
             $0.width.equalTo(ScreenUtils.getWidth(100))
         }
+        
         tripFriendsBtn.snp.makeConstraints{
             $0.centerY.equalToSuperview()
             $0.leading.equalTo(tripFriendsLabel.snp.trailing)

--- a/Going-iOS/Scene/OurToDo/Views/TripMiddleView.swift
+++ b/Going-iOS/Scene/OurToDo/Views/TripMiddleView.swift
@@ -62,8 +62,16 @@ final class TripMiddleView: UIView {
         btn.addTarget(self, action: #selector(pushToInquiryFriendsView), for: .touchUpInside)
         return btn
     }()
-    private lazy var tripFriendsCollectionView: UICollectionView = {setCollectionView()}()
-    
+    private lazy var tripFriendsCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .horizontal
+        flowLayout.itemSize = CGSize(width: ScreenUtils.getHeight(48) , height: ScreenUtils.getHeight(67))
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.backgroundColor = UIColor.white000
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.isScrollEnabled = true
+        return collectionView
+    }()
     private lazy var addButton: UIButton = {
         let btn = UIButton()
         btn.backgroundColor = .gray50
@@ -148,7 +156,13 @@ private extension TripMiddleView {
     
     func setHierarchy() {
         self.addSubview(ticketBoxImgView)
-        ticketBoxImgView.addSubviews(tripProgressLabel, percentageLabel, tripProgressBar, tripFriendsContainer, tripFriendsCollectionView, gradientView, addStackView)
+        ticketBoxImgView.addSubviews(tripProgressLabel,
+                                     percentageLabel,
+                                     tripProgressBar,
+                                     tripFriendsContainer,
+                                     tripFriendsCollectionView,
+                                     gradientView,
+                                     addStackView)
         tripFriendsContainer.addSubviews(tripFriendsLabel, tripFriendsBtn)
         addStackView.addArrangedSubviews(addButton, addLabel)
     }
@@ -220,33 +234,9 @@ private extension TripMiddleView {
         addButton.layer.cornerRadius = ScreenUtils.getHeight(23.5)
     }
     
-    func setLabel(text: String? = "", font: UIFont? = UIFont.pretendard(.body2_medi), textColor: UIColor? = UIColor.gray700, textAlignment: NSTextAlignment) -> UILabel {
-        let label = UILabel()
-        label.text = text
-        label.font = font
-        label.textColor = textColor
-        label.textAlignment = textAlignment
-        return label
-    }
-    
     func setDelegate() {
         self.tripFriendsCollectionView.dataSource = self
         self.tripFriendsCollectionView.delegate = self
-    }
-    
-    func setCollectionView() -> UICollectionView {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: setCollectionViewLayout())
-        collectionView.backgroundColor = UIColor.white000
-        collectionView.showsHorizontalScrollIndicator = false
-        collectionView.isScrollEnabled = true
-        return collectionView
-    }
-    
-    func setCollectionViewLayout() -> UICollectionViewFlowLayout {
-        let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.scrollDirection = .horizontal
-        flowLayout.itemSize = CGSize(width: ScreenUtils.getHeight(48) , height: ScreenUtils.getHeight(67))
-        return flowLayout
     }
     
     func registerCell() {

--- a/Going-iOS/Scene/ToDo/Cells/ToDoManagerCollectionViewCell.swift
+++ b/Going-iOS/Scene/ToDo/Cells/ToDoManagerCollectionViewCell.swift
@@ -35,18 +35,6 @@ final class ToDoManagerCollectionViewCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    func setLabelWithImage(label: UILabel, string: String) {
-        let string = NSAttributedString(string: " \(string)" )
-        let attachment = NSTextAttachment()
-        // 완료/미완료에 따라 자물쇠 이미지 세팅
-        let image = ImageLiterals.ToDo.orangeLock
-        attachment.image = image
-        // 이미지와 라벨 수직 정렬 맞춰주기
-        attachment.bounds = CGRect(x: 0, y: ScreenUtils.getHeight(-1), width: image.size.width, height: image.size.height)
-        let attachImg = NSAttributedString(attachment: attachment)
-        label.labelWithImg(composition: attachImg, string)
-    }
 
 }
 

--- a/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
+++ b/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
@@ -4,11 +4,9 @@ import SnapKit
 
 final class ToDoViewController: UIViewController {
 
-    private lazy var navigationBarView = DOONavigationBar(
-        self,
-        type: .backButtonWithTitle(StringLiterals.ToDo.inquiryToDo),
-        backgroundColor: .white000
-    )
+    private lazy var navigationBarView = DOONavigationBar(self,
+                                                          type: .backButtonWithTitle(StringLiterals.ToDo.inquiryToDo),
+                                                          backgroundColor: .white000)
     private let underlineView: UIView = {
         let view = UIView()
         view.backgroundColor = .gray100
@@ -43,20 +41,19 @@ final class ToDoViewController: UIViewController {
     //데이트피커에서 받은 데이트
     var selectedDate: Date?
     
-    
     // MARK: - Network
     
     var tripId: Int = 0
     var myId: Int = 0
     private var toDorequestData = CreateToDoRequestStruct(title: "", endDate: "", allocators: [], memo: "", secret: false)
+    private var saveToDoData: CreateToDoRequestStruct = .init(title: "", endDate: "", allocators: [], memo: "", secret: false)
 
     
     // MARK: - UI Components
     
+    var todoId: Int = 0
     var idSet: [Int] = []
     var buttonIndex: [Int] = []
-    var todoId: Int = 0
-    
     lazy var beforeVC: String = "" {
         didSet {
             self.todoManagerView.beforeVC = beforeVC
@@ -65,27 +62,21 @@ final class ToDoViewController: UIViewController {
             }
         }
     }
-    
     lazy var navigationBarTitle: String = "" {
         didSet {
             self.todoManagerView.navigationBarTitle = navigationBarTitle
         }
     }
-    
     lazy var fromOurTodoParticipants: [Participant] = [] {
         didSet {
             self.todoManagerView.fromOurTodoParticipants = fromOurTodoParticipants
         }
     }
-    
     lazy var manager: [Allocators] = [] {
         didSet {
             self.todoManagerView.allocators = manager
         }
     }
-
-    private var saveToDoData: CreateToDoRequestStruct = .init(title: "", endDate: "", allocators: [], memo: "", secret: false)
-    
     var data: GetDetailToDoResponseStuct? {
         didSet {
             guard let data else {return}
@@ -107,7 +98,6 @@ final class ToDoViewController: UIViewController {
             self.todoManagerView.todoManagerCollectionView.reloadData()
         }
     }
-    
     var setDefaultValue: [Any]? {
         didSet {
             guard let value = setDefaultValue else {return}
@@ -119,7 +109,6 @@ final class ToDoViewController: UIViewController {
             self.memoTextView.memoTextView.text = value[3] as? String ?? ""
         }
     }
-    
     var isActivateView: Bool? = false {
         didSet {
             guard let isActivateView else {return}
@@ -174,8 +163,14 @@ final class ToDoViewController: UIViewController {
     
     // 키보드 관련 알림 등록
     func addNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, 
+                                               selector: #selector(keyboardWillShow(_:)),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self, 
+                                               selector: #selector(keyboardWillHide(_:)),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
     }
     
     // 키보드 관련 알림 등록
@@ -193,9 +188,7 @@ final class ToDoViewController: UIViewController {
     
     @objc func keyboardWillShow(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
-              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
-            return
-        }
+              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
         
         if self.memoTextView.memoTextView.isFirstResponder {
             // memoTextView가 FirstResponder인 경우 contentInset을 조절
@@ -375,22 +368,9 @@ private extension ToDoViewController {
     
     // 조회 뷰 스타일 세팅 메서드
     func setInquiryStyle() {
-//        guard let todotext = todoTextfield.placeholder?.count else {return}
-//        guard let memotext = self.memoTextView.memoTextView.text?.count else {return}
         self.todoTextFieldView.setInquiryTextFieldStyle()
         self.endDateView.setInquiryEndDateStyle()
-//        todoTextfield.layer.borderColor = UIColor.gray700.cgColor
-//        todoTextfield.setPlaceholderColor(.gray700)
-//        countToDoCharacterLabel.textColor = .gray700
-//        countToDoCharacterLabel.text = "\(todotext)/15"
-//        deadlineTextfieldLabel.layer.borderColor = UIColor.gray700.cgColor
-//        deadlineTextfieldLabel.textColor = .gray700
-//        dropdownButton.setImage(ImageLiterals.ToDo.enabledDropdown, for: .normal)
         self.memoTextView.setInquiryMemoStyle()
-//        memoTextView.layer.borderColor = memoTextView.text == "" ? UIColor.gray200.cgColor : UIColor.gray700.cgColor
-//        memoTextView.textColor = memoTextView.text == "" ? UIColor.gray200 : UIColor.gray700
-//        countMemoCharacterLabel.text = "\(memotext)/1000"
-//        countMemoCharacterLabel.textColor = memoTextView.text == "" ? UIColor.gray200 : .gray700
     }
     
     /// 텍스트 필드에 들어갈 텍스트를 DateFormatter로  변환하는 메서드
@@ -406,17 +386,6 @@ private extension ToDoViewController {
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         self.present(bottomSheetVC, animated: false, completion: nil)
     }
-    
-//    func memoTextViewBlankCheck() {
-//        guard let textEmpty = memoTextView.text?.isEmpty else { return }
-//        if textEmpty {
-//            memoTextView.layer.borderColor = UIColor.gray200.cgColor
-//            self.countMemoCharacterLabel.textColor = .gray200
-//        } else {
-//            memoTextView.layer.borderColor = UIColor.gray700.cgColor
-//            self.countMemoCharacterLabel.textColor = .gray400
-//        }
-//    }
     
     func compareDate(userDate: Date) -> Bool {
         let dateFormatter = DateFormatter()

--- a/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
+++ b/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
@@ -551,10 +551,3 @@ extension ToDoViewController {
         }
     }
 }
-
-extension Date {
-    func convertToTimeZone(initTimeZone: TimeZone, timeZone: TimeZone) -> Date {
-        let delta = TimeInterval(initTimeZone.secondsFromGMT(for: self) - timeZone.secondsFromGMT(for: self))
-        return addingTimeInterval(delta)
-    }
-}

--- a/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
+++ b/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
@@ -7,32 +7,43 @@ final class ToDoViewController: UIViewController {
     private lazy var navigationBarView = DOONavigationBar(self,
                                                           type: .backButtonWithTitle(StringLiterals.ToDo.inquiryToDo),
                                                           backgroundColor: .white000)
+    
     private let underlineView: UIView = {
         let view = UIView()
         view.backgroundColor = .gray100
         return view
     }()
+    
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .white000
         return scrollView
     }()
+    
     private let contentView: UIView = {
         let view = UIView()
         view.backgroundColor = .white000
         return view
     }()
+    
     private let todoTextFieldView = ToDoTextFieldView()
+    
     private let endDateView = EndDateView()
+    
     private let bottomSheetVC = DatePickerBottomSheetViewController()
+    
     private let todoManagerView = ToDoManagerView()
+    
     private let memoTextView = MemoTextView()
+    
     private let buttonView: UIView = UIView()
+    
     private lazy var singleButtonView: DOOButton = {
         let singleBtn = DOOButton(type: .unabled, title: StringLiterals.ToDo.toSave)
         singleBtn.addTarget(self, action: #selector(saveToDo), for: .touchUpInside)
         return singleBtn
     }()
+    
     private lazy var doubleButtonView = DoubleButtonView()
     
     
@@ -44,16 +55,22 @@ final class ToDoViewController: UIViewController {
     // MARK: - Network
     
     var tripId: Int = 0
+    
     var myId: Int = 0
+    
     private var toDorequestData = CreateToDoRequestStruct(title: "", endDate: "", allocators: [], memo: "", secret: false)
+    
     private var saveToDoData: CreateToDoRequestStruct = .init(title: "", endDate: "", allocators: [], memo: "", secret: false)
 
     
     // MARK: - UI Components
     
     var todoId: Int = 0
+    
     var idSet: [Int] = []
+    
     var buttonIndex: [Int] = []
+    
     lazy var beforeVC: String = "" {
         didSet {
             self.todoManagerView.beforeVC = beforeVC
@@ -62,21 +79,25 @@ final class ToDoViewController: UIViewController {
             }
         }
     }
+    
     lazy var navigationBarTitle: String = "" {
         didSet {
             self.todoManagerView.navigationBarTitle = navigationBarTitle
         }
     }
+    
     lazy var fromOurTodoParticipants: [Participant] = [] {
         didSet {
             self.todoManagerView.fromOurTodoParticipants = fromOurTodoParticipants
         }
     }
+    
     lazy var manager: [Allocators] = [] {
         didSet {
             self.todoManagerView.allocators = manager
         }
     }
+    
     var data: GetDetailToDoResponseStuct? {
         didSet {
             guard let data else {return}
@@ -98,6 +119,7 @@ final class ToDoViewController: UIViewController {
             self.todoManagerView.todoManagerCollectionView.reloadData()
         }
     }
+    
     var setDefaultValue: [Any]? {
         didSet {
             guard let value = setDefaultValue else {return}
@@ -109,6 +131,7 @@ final class ToDoViewController: UIViewController {
             self.memoTextView.memoTextView.text = value[3] as? String ?? ""
         }
     }
+    
     var isActivateView: Bool? = false {
         didSet {
             guard let isActivateView else {return}
@@ -119,6 +142,7 @@ final class ToDoViewController: UIViewController {
             self.memoTextView.isUserInteractionEnabled = isActivateView ? true : false
         }
     }
+    
     
     // MARK: - Life Cycle
     
@@ -266,13 +290,11 @@ private extension ToDoViewController {
     func setHierachy() {
         self.view.addSubviews(navigationBarView, underlineView, scrollView)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(
-            todoTextFieldView,
-            endDateView,
-            todoManagerView,
-            memoTextView,
-            buttonView
-        )
+        contentView.addSubviews(todoTextFieldView,
+                                endDateView,
+                                todoManagerView,
+                                memoTextView,
+                                buttonView)
     }
     
     func setLayout() {

--- a/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
+++ b/Going-iOS/Scene/ToDo/ViewControllers/ToDoViewController.swift
@@ -4,7 +4,11 @@ import SnapKit
 
 final class ToDoViewController: UIViewController {
 
-    private lazy var navigationBarView = DOONavigationBar(self, type: .backButtonWithTitle(StringLiterals.ToDo.inquiryToDo), backgroundColor: .white000)
+    private lazy var navigationBarView = DOONavigationBar(
+        self,
+        type: .backButtonWithTitle(StringLiterals.ToDo.inquiryToDo),
+        backgroundColor: .white000
+    )
     private let underlineView: UIView = {
         let view = UIView()
         view.backgroundColor = .gray100
@@ -20,82 +24,11 @@ final class ToDoViewController: UIViewController {
         view.backgroundColor = .white000
         return view
     }()
-    private let todoLabel: UILabel = DOOLabel(font: .pretendard(.body2_bold), color: .gray700, text: StringLiterals.ToDo.todo)
-    
-    private lazy var todoTextfield: UITextField = {
-        let tf = UITextField()
-        tf.setTextField(forPlaceholder: "", forBorderColor: .gray200, forCornerRadius: 6)
-        tf.font = .pretendard(.body3_medi)
-        tf.setPlaceholderColor(.gray700)
-        tf.textColor = .gray700
-        tf.backgroundColor = .white000
-        tf.setLeftPadding(amount: 12)
-        tf.addTarget(self, action: #selector(todoTextFieldDidChange), for: .editingChanged)
-        return tf
-    }()
-    private let warningLabel: DOOLabel = {
-        let label = DOOLabel(font: .pretendard(.body3_medi), color: .red400)
-        label.isHidden = true
-        return label
-    }()
-    
-    private let memoWarningLabel: DOOLabel = {
-        let label = DOOLabel(font: .pretendard(.body3_medi), color: .red400)
-        label.isHidden = true
-        return label
-    }()
-        
-    private var todoTextFieldCount: Int = 0
-    private let countToDoCharacterLabel: UILabel = DOOLabel(font: .pretendard(.detail2_regular), color: .gray200, text: "0/15")
-    private let deadlineLabel: UILabel = DOOLabel(font: .pretendard(.body2_bold), color: .gray700, text: StringLiterals.ToDo.deadline)
-    private lazy var deadlineTextfieldLabel: DOOLabel = {
-        let label = DOOLabel(font: .pretendard(.body3_medi), color: .gray200, alignment: .left, padding: UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0))
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(presentToDatePicker) )
-        label.backgroundColor = .white000
-        label.layer.borderColor = UIColor.gray200.cgColor
-        label.layer.cornerRadius = 6
-        label.layer.borderWidth = 1
-        label.isUserInteractionEnabled = true
-        label.addGestureRecognizer(gesture)
-        return label
-    }()
-    
+    private let todoTextFieldView = ToDoTextFieldView()
+    private let endDateView = EndDateView()
     private let bottomSheetVC = DatePickerBottomSheetViewController()
-    private let dropdownContainer: UIView = UIView()
-    private lazy var dropdownButton: UIButton = {
-        let btn = UIButton()
-        btn.setImage(ImageLiterals.ToDo.disabledDropdown, for: .normal)
-        btn.backgroundColor = .white000
-        btn.addTarget(self, action: #selector(presentToDatePicker), for: .touchUpInside)
-        return btn
-    }()
-    private let managerLabel: UILabel = DOOLabel(font: .pretendard(.body2_bold), color: .gray700, text: StringLiterals.ToDo.allocation)
-    
-    private let todoManagerCollectionView: UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clear
-        collectionView.showsHorizontalScrollIndicator = false
-        collectionView.showsVerticalScrollIndicator = false
-        collectionView.isScrollEnabled = false
-        return collectionView
-    }()
-    
-    private let memoLabel: UILabel = DOOLabel(font: .pretendard(.body2_bold), color: .gray700, text: StringLiterals.ToDo.memo)
-    private var memoTextViewCount: Int = 0
-    private let memoTextView: UITextView = {
-        let tv = UITextView()
-        tv.backgroundColor = .white000
-        tv.textContainerInset = UIEdgeInsets(top: ScreenUtils.getHeight(12), left: ScreenUtils.getWidth(12), bottom: ScreenUtils.getHeight(12), right: ScreenUtils.getWidth(12))
-        tv.font = .pretendard(.body3_medi)
-        tv.textColor = .gray200
-        tv.layer.borderColor = UIColor.gray200.cgColor
-        tv.layer.cornerRadius = 6
-        tv.layer.borderWidth = 1
-        return tv
-    }()
-    private let countMemoCharacterLabel: UILabel = DOOLabel(font: .pretendard(.detail2_regular), color: .gray200, text: "0/1000")
+    private let todoManagerView = ToDoManagerView()
+    private let memoTextView = MemoTextView()
     private let buttonView: UIView = UIView()
     private lazy var singleButtonView: DOOButton = {
         let singleBtn = DOOButton(type: .unabled, title: StringLiterals.ToDo.toSave)
@@ -104,86 +37,96 @@ final class ToDoViewController: UIViewController {
     }()
     private lazy var doubleButtonView = DoubleButtonView()
     
+    
     // MARK: - Properties
     
     //데이트피커에서 받은 데이트
     var selectedDate: Date?
     
+    
     // MARK: - Network
     
     var tripId: Int = 0
-    
     var myId: Int = 0
-    
     private var toDorequestData = CreateToDoRequestStruct(title: "", endDate: "", allocators: [], memo: "", secret: false)
+
     
     // MARK: - UI Components
     
     var idSet: [Int] = []
-    
-    var fromOurTodoParticipants: [Participant] = []
-    
-    private var isTodoTextFieldGood: Bool = false
-    
-    var peopleCount: Int = 0
-    
     var buttonIndex: [Int] = []
-    
     var todoId: Int = 0
     
     lazy var beforeVC: String = "" {
         didSet {
+            self.todoManagerView.beforeVC = beforeVC
             if navigationBarTitle == "추가" && beforeVC == "my" {
-                self.manager = [.init(name: "혼자할일", isOwner: true)]
-                peopleCount = 1
+                self.todoManagerView.allocators = [.init(name: "혼자할일", isOwner: true)]
             }
         }
     }
     
-    lazy var navigationBarTitle: String = ""
-    var manager: [Allocators] = []
-    private var memoTextviewPlaceholder: String = ""
-    private var todoTextfieldPlaceholder: String = ""
+    lazy var navigationBarTitle: String = "" {
+        didSet {
+            self.todoManagerView.navigationBarTitle = navigationBarTitle
+        }
+    }
+    
+    lazy var fromOurTodoParticipants: [Participant] = [] {
+        didSet {
+            self.todoManagerView.fromOurTodoParticipants = fromOurTodoParticipants
+        }
+    }
+    
+    lazy var manager: [Allocators] = [] {
+        didSet {
+            self.todoManagerView.allocators = manager
+        }
+    }
+
     private var saveToDoData: CreateToDoRequestStruct = .init(title: "", endDate: "", allocators: [], memo: "", secret: false)
     
     var data: GetDetailToDoResponseStuct? {
         didSet {
             guard let data else {return}
-            todoTextfield.text = data.title
-            deadlineTextfieldLabel.text = data.endDate
-            manager = data.allocators
+            self.todoTextFieldView.todoTextfield.text = data.title
+            self.endDateView.deadlineTextfieldLabel.text = data.endDate
+            self.todoManagerView.allocators = data.allocators
+            self.todoManagerView.isSecret = data.secret
             if data.secret == true {
-                self.manager[0].name = "혼자할일"
-                self.manager.append(Allocators.EmptyData)
+                self.todoManagerView.allocators[0].name = "혼자할일"
+                self.todoManagerView.allocators.append(Allocators.EmptyData)
             }
             if navigationBarTitle == "조회" {
                 navigationBarView.titleLabel.text = "할일 조회"
-                setDefaultValue = [data.title, data.endDate, self.manager , data.memo ?? ""]
+                setDefaultValue = [data.title, data.endDate, self.todoManagerView.allocators, data.memo ?? ""]
                 setInquiryStyle()
             }
-            memoTextView.text = data.memo
+            self.memoTextView.memoTextView.text = data.memo
             
-            self.todoManagerCollectionView.reloadData()
+            self.todoManagerView.todoManagerCollectionView.reloadData()
         }
     }
+    
     var setDefaultValue: [Any]? {
         didSet {
             guard let value = setDefaultValue else {return}
-            todoTextfieldPlaceholder = value[0] as? String ?? ""
-            todoTextfield.placeholder = todoTextfieldPlaceholder
-            deadlineTextfieldLabel.text = value[1] as? String
-            manager = value[2] as? [Allocators] ?? []
-            memoTextviewPlaceholder = value[3] as? String ?? ""
-            memoTextView.text = memoTextviewPlaceholder
+            self.todoTextFieldView.todoTextfieldPlaceholder = value[0] as? String ?? ""
+            self.todoTextFieldView.todoTextfield.placeholder = value[0] as? String ?? ""
+            self.endDateView.deadlineTextfieldLabel.text = value[1] as? String
+            self.todoManagerView.allocators = value[2] as? [Allocators] ?? []
+            self.memoTextView.memoTextviewPlaceholder = value[3] as? String ?? ""
+            self.memoTextView.memoTextView.text = value[3] as? String ?? ""
         }
     }
     
     var isActivateView: Bool? = false {
         didSet {
             guard let isActivateView else {return}
-            self.todoTextfield.isUserInteractionEnabled = isActivateView ? true : false
-            self.deadlineTextfieldLabel.isUserInteractionEnabled = isActivateView ? true : false
-            self.todoManagerCollectionView.isUserInteractionEnabled = isActivateView ? true : false
+            self.todoManagerView.isActivateView = isActivateView
+            self.todoTextFieldView.todoTextfield.isUserInteractionEnabled = isActivateView ? true : false
+            self.endDateView.deadlineTextfieldLabel.isUserInteractionEnabled = isActivateView ? true : false
+            self.todoManagerView.todoManagerCollectionView.isUserInteractionEnabled = isActivateView ? true : false
             self.memoTextView.isUserInteractionEnabled = isActivateView ? true : false
         }
     }
@@ -197,11 +140,10 @@ final class ToDoViewController: UIViewController {
         setLayout()
         setDelegate()
         setStyle()
-        registerCell()
         
         if navigationBarTitle == "추가" {
             navigationBarView.titleLabel.text = "할일 추가"
-            setDefaultValue = ["할일을 입력해 주세요", "날짜를 선택해 주세요", self.manager, "메모를 입력해 주세요"]
+            setDefaultValue = ["할일을 입력해 주세요", "날짜를 선택해 주세요", self.todoManagerView.allocators, "메모를 입력해 주세요"]
         }
     }
     
@@ -242,7 +184,7 @@ final class ToDoViewController: UIViewController {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
-    /// 키보드내리기
+    // 키보드내리기
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?){
         self.view.endEditing(true)
     }
@@ -254,11 +196,15 @@ final class ToDoViewController: UIViewController {
               let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
             return
         }
-        if memoTextView.isFirstResponder {
+        
+        if self.memoTextView.memoTextView.isFirstResponder {
             // memoTextView가 FirstResponder인 경우 contentInset을 조절
             let contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardFrame.size.height - ScreenUtils.getHeight(60), right: 0)
             scrollView.contentInset = contentInset
             scrollView.scrollIndicatorInsets = contentInset
+
+            let rect = self.memoTextView.convert(self.memoTextView.bounds, to: scrollView)
+            scrollView.scrollRectToVisible(rect, animated: true)
         }
     }
     
@@ -270,7 +216,7 @@ final class ToDoViewController: UIViewController {
         
         // 버튼 뷰의 위치를 원래대로 조절.
         buttonView.snp.remakeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
+            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(24))
             $0.bottom.equalTo(contentView.snp.bottom).inset(ScreenUtils.getHeight(40))
             $0.height.equalTo(ScreenUtils.getHeight(50))
         }
@@ -280,36 +226,6 @@ final class ToDoViewController: UIViewController {
         }
     }
     
-    @objc
-    func presentToDatePicker(for button: UIButton) {
-        showDatePicker(for: button)
-        dropdownButton.setImage(ImageLiterals.ToDo.tappedDropdown, for: .normal)
-    }
-    
-    // 담당자 버튼 탭 시 버튼 색상 변경 & 배열에 담아주는 메서드
-    @objc
-    func didTapToDoManagerButton(_ sender: UIButton) {
-        guard let isActivateView = self.isActivateView else {return}
-        if isActivateView {
-            
-            changeButtonConfig(isSelected: sender.isSelected, btn: sender)
-            
-            // 아워투두의 할일 추가의 경우
-            
-            if beforeVC == "our" {
-                if sender.isSelected {
-                    buttonIndex.removeAll(where: { $0 == sender.tag })
-                } else {
-                    // 여기에서 필요한 작업을 수행할 수 있습니다.
-                    buttonIndex.append(sender.tag)
-                }
-            }
-            updateSingleButtonState()
-            sender.isSelected = !sender.isSelected
-        }
-    }
-    
-    
     @objc func viewTapped(sender: UITapGestureRecognizer) {
         // 화면을 탭하면 키보드가 닫히도록 함
         view.endEditing(true)
@@ -318,14 +234,14 @@ final class ToDoViewController: UIViewController {
     // 저장 버튼 탭 시 데이터를 배열에 담아주고 아워투두 뷰로 돌아가는 메서드
     @objc
     func saveToDo() {
-        let todo = todoTextfield.text ?? ""
-        let deadline = (deadlineTextfieldLabel.text == "날짜를 선택해 주세요" ? "" : deadlineTextfieldLabel.text) ?? ""
-        let memo = (memoTextView.text == memoTextviewPlaceholder ? "" : memoTextView.text) ?? ""
+        let todo = self.todoTextFieldView.todoTextfield.text ?? ""
+        let deadline = (self.endDateView.deadlineTextfieldLabel.text == "날짜를 선택해 주세요" ? "" : self.endDateView.deadlineTextfieldLabel.text) ?? ""
+        let memo = (self.memoTextView.memoTextView.text == self.memoTextView.memoTextviewPlaceholder ? "" : self.memoTextView.memoTextView.text) ?? ""
         let secret = beforeVC == "our" ? false : true
         if !todo.isEmpty && !deadline.isEmpty {
             if !buttonIndex.isEmpty {
                 for i in buttonIndex {
-                    idSet.append(fromOurTodoParticipants[i].participantId)
+                    idSet.append(self.todoManagerView.fromOurTodoParticipants[i].participantId)
                 }
             }
             if beforeVC == "my" {
@@ -342,10 +258,10 @@ final class ToDoViewController: UIViewController {
     
     @objc
     func todoTextFieldDidChange() {
-        guard let text = todoTextfield.text else { return }
-        todoTextFieldCount = text.count
-        countToDoCharacterLabel.text = "\(todoTextFieldCount)/15"
-        todoTextFieldCheck()
+        guard let text = self.todoTextFieldView.todoTextfield.text else { return }
+        self.todoTextFieldView.todoTextFieldCount = text.count
+        self.todoTextFieldView.countToDoCharacterLabel.text = "\(self.todoTextFieldView.todoTextFieldCount)/15"
+        self.todoTextFieldView.todoTextFieldCheck()
         updateSingleButtonState()
     }
 }
@@ -358,39 +274,34 @@ private extension ToDoViewController {
         self.view.addSubviews(navigationBarView, underlineView, scrollView)
         scrollView.addSubview(contentView)
         contentView.addSubviews(
-            todoLabel,
-            todoTextfield,
-            warningLabel,
-            countToDoCharacterLabel,
-            deadlineLabel,
-            deadlineTextfieldLabel,
-            managerLabel,
-            todoManagerCollectionView,
-            memoLabel,
+            todoTextFieldView,
+            endDateView,
+            todoManagerView,
             memoTextView,
-            memoWarningLabel,
-            countMemoCharacterLabel,
             buttonView
         )
-        deadlineTextfieldLabel.addSubview(dropdownButton)
     }
     
     func setLayout() {
+        
         navigationBarView.snp.makeConstraints{
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(50))
         }
+        
         underlineView.snp.makeConstraints{
             $0.top.equalTo(navigationBarView.snp.bottom)
             $0.height.equalTo(1)
             $0.leading.trailing.equalToSuperview()
         }
+        
         scrollView.snp.makeConstraints{
             $0.top.equalTo(underlineView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
+        
         contentView.snp.makeConstraints{
             $0.top.equalTo(scrollView)
             $0.width.equalToSuperview()
@@ -398,72 +309,36 @@ private extension ToDoViewController {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(scrollView.snp.height).priority(.low)
         }
+        
         guard let isActivateView else {return}
         isActivateView ? setButtonView(button: singleButtonView) : setButtonView(button: doubleButtonView)
-        todoLabel.snp.makeConstraints{
+
+        todoTextFieldView.snp.makeConstraints {
             $0.top.equalTo(contentView).inset(ScreenUtils.getHeight(40))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(23))
-        }
-        todoTextfield.snp.makeConstraints{
-            $0.top.equalTo(todoLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(48))
-        }
-        warningLabel.snp.makeConstraints {
-            $0.top.equalTo(todoTextfield.snp.bottom).offset(4)
-            $0.leading.equalTo(todoTextfield.snp.leading).offset(4)
+            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(24))
+            $0.height.equalTo(ScreenUtils.getHeight(101))
         }
         
-        memoWarningLabel.snp.makeConstraints {
-            $0.top.equalTo(memoTextView.snp.bottom).offset(4)
-            $0.leading.equalTo(memoTextView.snp.leading).offset(4)
+        endDateView.snp.makeConstraints {
+            $0.top.equalTo(todoTextFieldView.snp.bottom).offset(ScreenUtils.getHeight(16))
+            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(24))
+            $0.height.equalTo(ScreenUtils.getHeight(79))
         }
-        countToDoCharacterLabel.snp.makeConstraints{
-            $0.top.equalTo(todoTextfield.snp.bottom).offset(4)
-            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(22))
+        
+        todoManagerView.snp.makeConstraints {
+            $0.top.equalTo(endDateView.snp.bottom).offset(ScreenUtils.getHeight(38))
+            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(24))
+            $0.height.equalTo(ScreenUtils.getHeight(55))
         }
-        deadlineLabel.snp.makeConstraints{
-            $0.top.equalTo(countToDoCharacterLabel.snp.bottom).offset(ScreenUtils.getHeight(16))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(23))
+        
+        memoTextView.snp.makeConstraints {
+            $0.top.equalTo(todoManagerView.snp.bottom).offset(ScreenUtils.getHeight(38))
+            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(24))
+            $0.height.equalTo(ScreenUtils.getHeight(192))
         }
-        deadlineTextfieldLabel.snp.makeConstraints{
-            $0.top.equalTo(deadlineLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(48))
-        }
-        dropdownButton.snp.makeConstraints{
-            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(12))
-            $0.centerY.equalToSuperview()
-            $0.size.equalTo(ScreenUtils.getHeight(22))
-        }
-        managerLabel.snp.makeConstraints{
-            $0.top.equalTo(deadlineTextfieldLabel.snp.bottom).offset(ScreenUtils.getHeight(38))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(23))
-        }
-        todoManagerCollectionView.snp.makeConstraints{
-            $0.top.equalTo(managerLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(24))
-        }
-        memoLabel.snp.makeConstraints{
-            $0.top.equalTo(todoManagerCollectionView.snp.bottom).offset(ScreenUtils.getHeight(38))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(24))
-        }
-        memoTextView.snp.makeConstraints{
-            $0.top.equalTo(memoLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.height.equalTo(ScreenUtils.getHeight(140))
-        }
-        countMemoCharacterLabel.snp.makeConstraints{
-            $0.top.equalTo(memoTextView.snp.bottom).offset(4)
-            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(22))
-        }
+        
         buttonView.snp.makeConstraints{
-            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
+            $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(24))
             $0.height.equalTo(ScreenUtils.getHeight(50))
             $0.bottom.equalToSuperview().inset(40)
         }
@@ -477,33 +352,15 @@ private extension ToDoViewController {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
         view.addGestureRecognizer(tapGesture)
         navigationBarView.backgroundColor = .white000
-        dropdownContainer.backgroundColor = .white
     }
     
     func setDelegate() {
-        todoTextfield.delegate = self
-        todoManagerCollectionView.dataSource = self
-        todoManagerCollectionView.delegate = self
+        todoTextFieldView.delegate = self
+        endDateView.delegate = self
+        todoManagerView.delegate = self
         memoTextView.delegate = self
         bottomSheetVC.delegate = self
         doubleButtonView.delegate = self
-    }
-    
-    func registerCell() {
-        self.todoManagerCollectionView.register(ToDoManagerCollectionViewCell.self, forCellWithReuseIdentifier: ToDoManagerCollectionViewCell.identifier)
-    }
-    
-    /// 담당자 버튼 클릭 시 버튼 스타일 변경해주는 메소드
-    func changeButtonConfig(isSelected: Bool, btn: UIButton) {
-        if !isSelected {
-            btn.setTitleColor(.white000, for: .normal)
-            btn.backgroundColor = btn.tag == 0 ? UIColor.red500 : UIColor.gray400
-            btn.layer.borderColor = btn.tag == 0 ? UIColor.red500.cgColor : UIColor.gray400.cgColor
-        }else {
-            btn.setTitleColor(.gray300, for: .normal)
-            btn.backgroundColor = .white000
-            btn.layer.borderColor = UIColor.gray300.cgColor
-        }
     }
     
     // 추가, 조회 뷰에 따라 하단 버튼을 세팅해주는 메서드
@@ -518,19 +375,22 @@ private extension ToDoViewController {
     
     // 조회 뷰 스타일 세팅 메서드
     func setInquiryStyle() {
-        guard let todotext = todoTextfield.placeholder?.count else {return}
-        guard let memotext = memoTextView.text?.count else {return}
-        todoTextfield.layer.borderColor = UIColor.gray700.cgColor
-        todoTextfield.setPlaceholderColor(.gray700)
-        countToDoCharacterLabel.textColor = .gray700
-        countToDoCharacterLabel.text = "\(todotext)/15"
-        deadlineTextfieldLabel.layer.borderColor = UIColor.gray700.cgColor
-        deadlineTextfieldLabel.textColor = .gray700
-        dropdownButton.setImage(ImageLiterals.ToDo.enabledDropdown, for: .normal)
-        memoTextView.layer.borderColor = memoTextView.text == "" ? UIColor.gray200.cgColor : UIColor.gray700.cgColor
-        memoTextView.textColor = memoTextView.text == "" ? UIColor.gray200 : UIColor.gray700
-        countMemoCharacterLabel.text = "\(memotext)/1000"
-        countMemoCharacterLabel.textColor = memoTextView.text == "" ? UIColor.gray200 : .gray700
+//        guard let todotext = todoTextfield.placeholder?.count else {return}
+//        guard let memotext = self.memoTextView.memoTextView.text?.count else {return}
+        self.todoTextFieldView.setInquiryTextFieldStyle()
+        self.endDateView.setInquiryEndDateStyle()
+//        todoTextfield.layer.borderColor = UIColor.gray700.cgColor
+//        todoTextfield.setPlaceholderColor(.gray700)
+//        countToDoCharacterLabel.textColor = .gray700
+//        countToDoCharacterLabel.text = "\(todotext)/15"
+//        deadlineTextfieldLabel.layer.borderColor = UIColor.gray700.cgColor
+//        deadlineTextfieldLabel.textColor = .gray700
+//        dropdownButton.setImage(ImageLiterals.ToDo.enabledDropdown, for: .normal)
+        self.memoTextView.setInquiryMemoStyle()
+//        memoTextView.layer.borderColor = memoTextView.text == "" ? UIColor.gray200.cgColor : UIColor.gray700.cgColor
+//        memoTextView.textColor = memoTextView.text == "" ? UIColor.gray200 : UIColor.gray700
+//        countMemoCharacterLabel.text = "\(memotext)/1000"
+//        countMemoCharacterLabel.textColor = memoTextView.text == "" ? UIColor.gray200 : .gray700
     }
     
     /// 텍스트 필드에 들어갈 텍스트를 DateFormatter로  변환하는 메서드
@@ -542,21 +402,21 @@ private extension ToDoViewController {
     }
     
     /// DatePicker Presnet 하는 메서드
-    func showDatePicker(for button: UIButton) {
+    func showDatePicker() {
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         self.present(bottomSheetVC, animated: false, completion: nil)
     }
     
-    func memoTextViewBlankCheck() {
-        guard let textEmpty = memoTextView.text?.isEmpty else { return }
-        if textEmpty {
-            memoTextView.layer.borderColor = UIColor.gray200.cgColor
-            self.countMemoCharacterLabel.textColor = .gray200
-        } else {
-            memoTextView.layer.borderColor = UIColor.gray700.cgColor
-            self.countMemoCharacterLabel.textColor = .gray400
-        }
-    }
+//    func memoTextViewBlankCheck() {
+//        guard let textEmpty = memoTextView.text?.isEmpty else { return }
+//        if textEmpty {
+//            memoTextView.layer.borderColor = UIColor.gray200.cgColor
+//            self.countMemoCharacterLabel.textColor = .gray200
+//        } else {
+//            memoTextView.layer.borderColor = UIColor.gray700.cgColor
+//            self.countMemoCharacterLabel.textColor = .gray400
+//        }
+//    }
     
     func compareDate(userDate: Date) -> Bool {
         let dateFormatter = DateFormatter()
@@ -565,7 +425,7 @@ private extension ToDoViewController {
         
         //유저가 입력한 날짜를 스트링으로 바꿈
         let formattedDateString = dateFormatter.string(from: userDate)
-        deadlineTextfieldLabel.text = formattedDateString
+        self.endDateView.deadlineTextfieldLabel.text = formattedDateString
         
         //유저가 선택한 날짜
         let userPickedDate = userDate
@@ -586,259 +446,62 @@ private extension ToDoViewController {
         }
     }
     
-    func todoTextFieldCheck() {
-        guard let text = todoTextfield.text else { return }
+    func updateSingleButtonState() {
+        let isAllocatorFilled = ((beforeVC == "our") && (buttonIndex.isEmpty == false)) || (beforeVC == "my")
+        let isTodoTextFieldEmpty = self.todoTextFieldView.todoTextfield.text!.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let isDateSet = self.endDateView.deadlineTextfieldLabel.text != "날짜를 선택해 주세요"
         
-        if text.count > 15 {
-            todoTextfield.layer.borderColor = UIColor.red500.cgColor
-            countToDoCharacterLabel.textColor = .red500
-            warningLabel.text = "내용은 15자 이하여야 합니다"
-            warningLabel.isHidden = false
-            self.isTodoTextFieldGood = false
-            
-        } else if text.count == 0 {
-            todoTextfield.layer.borderColor = UIColor.gray200.cgColor
-            countToDoCharacterLabel.textColor = .gray200
-            warningLabel.isHidden = true
-            self.isTodoTextFieldGood = false
-            
-        } else if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            self.isTodoTextFieldGood = false
-            
-            todoTextfield.layer.borderColor = UIColor.red500.cgColor
-            countToDoCharacterLabel.textColor = .red500
-            warningLabel.text = "내용에는 공백만 입력할 수 없어요"
-            warningLabel.isHidden = false
-        }  else {
-            todoTextfield.layer.borderColor = UIColor.gray700.cgColor
-            countToDoCharacterLabel.textColor = .gray700
-            warningLabel.isHidden = true
-            self.isTodoTextFieldGood = true
-        }
-        
-        countToDoCharacterLabel.text = "\(text.count)/15"
-        updateSingleButtonState()
+        singleButtonView.currentType = ( !isTodoTextFieldEmpty
+                                         && self.todoTextFieldView.todoTextfield.text?.count ?? 0 <= 15
+                                         && isDateSet
+                                         && isAllocatorFilled
+                                         && self.memoTextView.memoTextView.text.count <= 1000) ? .enabled : .unabled
     }
 }
+
 
 // MARK: - Extension
 
-extension ToDoViewController: UICollectionViewDataSource{
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        // 마이투두 - 할일추가 - 1로 픽스
-        
-        if beforeVC == "our" {
-            if navigationBarTitle == "추가" {
-                return self.fromOurTodoParticipants.count
-            } else {
-                return self.manager.count
-            }
-        }
-        else {
-            return self.manager.count
-        }
+extension ToDoViewController: ToDoTextFieldDelegate {
+    func checkTextFieldState() {
+        self.updateSingleButtonState()
     }
-    
-    func textViewCountCheck() {
-        
-        guard let text = memoTextView.text else { return }
-        
-        if text.count > 1000 {
-            memoTextView.layer.borderColor = UIColor.red500.cgColor
-            countMemoCharacterLabel.textColor = .red500
-            warningLabel.text = "메모는 1000자를 초과할 수 없습니다."
-            memoWarningLabel.isHidden = false
-        } else {
-            memoWarningLabel.isHidden = true
+}
+
+extension ToDoViewController: EndDateViewDelegate {
+    func presentToDatePicker() {
+        showDatePicker()
+        self.endDateView.dropdownButton.setImage(ImageLiterals.ToDo.tappedDropdown, for: .normal)
+    }
+}
+
+extension ToDoViewController: ToDoManagerViewDelegate {
+    func tapToDoManagerButton(_ sender: UIButton) {
+        guard let isActivateView = self.isActivateView else {return}
+        if isActivateView {
             
-        }
-    }
-    
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        
-        guard let managerCell = collectionView.dequeueReusableCell(withReuseIdentifier: ToDoManagerCollectionViewCell.identifier, for: indexPath) as? ToDoManagerCollectionViewCell else {return UICollectionViewCell()}
-        
-        var name = ""
-        if beforeVC == "our" {
-            if navigationBarTitle == "추가" {
-                name = fromOurTodoParticipants[indexPath.row].name
-            } else {
-                name = manager[indexPath.row].name
-            }
-        } else {
-            name = manager[indexPath.row].name
-        }
-        
-        managerCell.managerButton.isEnabled = true
-        managerCell.managerButton.setTitle(name, for: .normal)
-        managerCell.managerButton.tag = indexPath.row
-        managerCell.managerButton.addTarget(self, action: #selector(didTapToDoManagerButton(_:)), for: .touchUpInside)
-        //아워투두 -> 조회
-        //다 선택된 옵션
-        //마이투두 -> 조회
-        //혼자할일 + 라벨
-        //아워투두
-        if beforeVC == "our" {
-            //조회
-            if isActivateView == false {
-                managerCell.managerButton.isSelected = true
-                managerCell.managerButton.setTitleColor(.white000, for: .normal)
-                if manager[indexPath.row].isOwner {
-                    managerCell.managerButton.backgroundColor = .red500
-                    managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
+            self.todoManagerView.changeButtonConfig(isSelected: sender.isSelected, btn: sender)
+            
+            // 아워투두의 할일 추가의 경우
+            
+            if beforeVC == "our" {
+                if sender.isSelected {
+                    buttonIndex.removeAll(where: { $0 == sender.tag })
                 } else {
-                    managerCell.managerButton.backgroundColor = .gray400
-                    managerCell.managerButton.layer.borderColor = UIColor.gray400.cgColor
-                }
-            } // 추가
-            else {
-                managerCell.managerButton.backgroundColor = .white000
-                managerCell.managerButton.setTitleColor(.gray300, for: .normal)
-                managerCell.managerButton.layer.borderColor = UIColor.gray300.cgColor
-            }
-        }// 마이투두
-        else {
-            // 조회
-            if isActivateView == false {
-                managerCell.managerButton.isSelected = true
-                // 혼자 할 일
-                if data?.secret == true {
-                    //설명라벨 세팅
-                    if manager[indexPath.row].name == "나만 볼 수 있는 할일이에요" {
-                        managerCell.managerButton.isEnabled = false
-                        managerCell.managerButton.backgroundColor = .white000
-                        managerCell.managerButton.layer.borderColor = UIColor.white000.cgColor
-                        
-                        managerCell.managerButton.setTitleColor(.gray200, for: .normal)
-                    } else {
-                        managerCell.managerButton.setImage(ImageLiterals.ToDo.orangeLock, for: .normal)
-                        managerCell.managerButton.setTitleColor(.red500, for: .normal)
-                        managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
-                        managerCell.managerButton.backgroundColor = .white000
-                    }
-                } else{
-                    managerCell.managerButton.setTitleColor(.white000, for: .normal)
-                    if manager[indexPath.row].isOwner { //owner
-                        managerCell.managerButton.backgroundColor = UIColor.red500
-                        managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
-                    }else {
-                        managerCell.managerButton.backgroundColor = UIColor.gray400
-                        managerCell.managerButton.layer.borderColor = UIColor.gray400.cgColor
-                    }
-                }
-            }// 추가
-            else {
-                //설명라벨 세팅
-                if manager[indexPath.row].name == "나만 볼 수 있는 할일이에요" {
-                    managerCell.managerButton.isEnabled = true
-                    managerCell.managerButton.backgroundColor = .white000
-                    managerCell.managerButton.layer.borderColor = UIColor.white000.cgColor
-                    managerCell.managerButton.setTitleColor(.white000, for: .normal)
-                } else {
-                    managerCell.managerButton.setImage(ImageLiterals.ToDo.orangeLock, for: .normal)
-                    managerCell.managerButton.setTitleColor(.red500, for: .normal)
-                    managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
-                    managerCell.managerButton.backgroundColor = .white000
-                    managerCell.managerButton.isUserInteractionEnabled = false
+                    buttonIndex.append(sender.tag)
                 }
             }
-        }
-        return managerCell
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
-    }
-}
-
-extension ToDoViewController: UITextViewDelegate {
-    
-    func textViewDidBeginEditing (_ textView: UITextView) {
-        todoTextfield.resignFirstResponder()
-        textView.becomeFirstResponder()
-        
-        if textView.text == memoTextviewPlaceholder {
-            textView.text = ""
-            textView.textColor = .gray700
-        }
-        textViewCountCheck()
-    }
-    
-    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        if let char = text.cString(using: String.Encoding.utf8) {
-            let isBackSpace = strcmp(char, "\\b")
-            if isBackSpace == -92 {
-                return true
-            }
-        }
-        
-        return true
-    }
-    
-    func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = memoTextviewPlaceholder
-            textView.textColor = .gray200
-            textViewCountCheck()
-        }
-        
-        
-    }
-    
-    func textViewDidChange(_ textView: UITextView) {
-        if textView == memoTextView {
-            let memoTextViewCount = textView.text.count
-            countMemoCharacterLabel.text = "\(memoTextViewCount)/1000"
-            memoTextViewBlankCheck()
-            textViewCountCheck()
             updateSingleButtonState()
+            sender.isSelected = !sender.isSelected
         }
     }
 }
 
-extension ToDoViewController: UITextFieldDelegate {
-    func textFieldDidBeginEditing (_ textField: UITextField) {
-        updateSingleButtonState()
-        todoTextFieldCheck()
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        todoTextFieldCheck()
-        updateSingleButtonState()
-    }
-    
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if let char = string.cString(using: String.Encoding.utf8) {
-            let isBackSpace = strcmp(char, "\\b")
-            if isBackSpace == -92 {
-                return true
-            }
-        }
-        return true
-    }
-    
-    /// 엔터 키 누르면 키보드 내리는 메서드
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
-        return true
+extension ToDoViewController: MemoTextViewDelegate {
+    func checkMemoState() {
+        self.updateSingleButtonState()
     }
 }
-
-extension ToDoViewController {
-    func updateSingleButtonState() {
-        let isAllocatorFilled = ((beforeVC == "our") && (buttonIndex.isEmpty == false)) || (beforeVC == "my")
-        let isTodoTextFieldEmpty = todoTextfield.text!.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let isDateSet = deadlineTextfieldLabel.text != "날짜를 선택해 주세요"
-        
-        singleButtonView.currentType = ( !isTodoTextFieldEmpty
-                                         && todoTextfield.text?.count ?? 0 <= 15
-                                         && isDateSet
-                                         && isAllocatorFilled
-                                         && memoTextView.text.count <= 1000) ? .enabled : .unabled
-    }
-}
-
 
 extension ToDoViewController: BottomSheetDelegate {
     
@@ -848,10 +511,10 @@ extension ToDoViewController: BottomSheetDelegate {
         self.selectedDate = date
         
         let formattedDate = dateFormat(date: date)
-        deadlineTextfieldLabel.text = formattedDate
-        deadlineTextfieldLabel.textColor = .gray700
-        deadlineTextfieldLabel.layer.borderColor = UIColor.gray700.cgColor
-        dropdownButton.setImage(ImageLiterals.ToDo.enabledDropdown, for: .normal)
+        self.endDateView.deadlineTextfieldLabel.text = formattedDate
+        self.endDateView.deadlineTextfieldLabel.textColor = .gray700
+        self.endDateView.deadlineTextfieldLabel.layer.borderColor = UIColor.gray700.cgColor
+        self.endDateView.dropdownButton.setImage(ImageLiterals.ToDo.enabledDropdown, for: .normal)
         
         if compareDate(userDate: date) {
             updateSingleButtonState()
@@ -866,41 +529,6 @@ extension ToDoViewController: DoubleButtonDelegate {
     
     func tapDeleteButton() {
         deleteTodo()
-    }
-}
-
-extension ToDoViewController: UICollectionViewDelegateFlowLayout {
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return ScreenUtils.getWidth(3)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return ScreenUtils.getWidth(3)
-    }
-    
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-                
-        if beforeVC == "my" {
-            if navigationBarTitle == "추가" {
-               return CGSize(width: ScreenUtils.getWidth(66), height: ScreenUtils.getHeight(20))
-                
-            //조회
-            } else {
-                if data?.secret == true {
-                    if indexPath.row == 0 {
-                        return CGSize(width: ScreenUtils.getWidth(66), height: ScreenUtils.getHeight(20))
-                    } else {
-                        return CGSize(width: ScreenUtils.getWidth(140), height: ScreenUtils.getHeight(18))
-                    }
-                } else {
-                    return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
-                    
-                }
-            }
-        }
-        return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
     }
 }
 

--- a/Going-iOS/Scene/ToDo/Views/DoubleButtonView.swift
+++ b/Going-iOS/Scene/ToDo/Views/DoubleButtonView.swift
@@ -17,12 +17,14 @@ final class DoubleButtonView: UIView {
         stackView.backgroundColor = .white000
         return stackView
     }()
+    
     private lazy var button1: DOOButton = {
         let btn = DOOButton(type: .white, title: "삭제하기")
         btn.addTarget(self, action: #selector(tapDeleteButton), for: .touchUpInside)
         btn.tag = 1
         return btn
     }()
+    
     private lazy var button2: DOOButton = {
         let btn = DOOButton(type: .enabled, title: "수정하기")
         btn.addTarget(self, action: #selector(tapEditButton), for: .touchUpInside)

--- a/Going-iOS/Scene/ToDo/Views/EndDateView.swift
+++ b/Going-iOS/Scene/ToDo/Views/EndDateView.swift
@@ -18,6 +18,7 @@ class EndDateView: UIView {
         color: .gray700,
         text: StringLiterals.ToDo.deadline
     )
+    
     lazy var deadlineTextfieldLabel: DOOLabel = {
         let label = DOOLabel(
             font: .pretendard(.body3_medi),
@@ -34,6 +35,7 @@ class EndDateView: UIView {
         label.addGestureRecognizer(gesture)
         return label
     }()
+    
     lazy var dropdownButton: UIButton = {
         let btn = UIButton()
         btn.setImage(ImageLiterals.ToDo.disabledDropdown, for: .normal)
@@ -82,11 +84,13 @@ private extension EndDateView {
             $0.top.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(23))
         }
+        
         deadlineTextfieldLabel.snp.makeConstraints{
             $0.top.equalTo(deadlineLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(48))
         }
+        
         dropdownButton.snp.makeConstraints{
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(12))
             $0.centerY.equalToSuperview()

--- a/Going-iOS/Scene/ToDo/Views/EndDateView.swift
+++ b/Going-iOS/Scene/ToDo/Views/EndDateView.swift
@@ -1,0 +1,20 @@
+//
+//  EndDateView.swift
+//  Going-iOS
+//
+//  Created by 윤희슬 on 1/24/24.
+//
+
+import UIKit
+
+class EndDateView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Going-iOS/Scene/ToDo/Views/EndDateView.swift
+++ b/Going-iOS/Scene/ToDo/Views/EndDateView.swift
@@ -7,14 +7,91 @@
 
 import UIKit
 
+protocol EndDateViewDelegate: AnyObject {
+    func presentToDatePicker()
+}
+
 class EndDateView: UIView {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    private let deadlineLabel = DOOLabel(
+        font: .pretendard(.body2_bold),
+        color: .gray700,
+        text: StringLiterals.ToDo.deadline
+    )
+    lazy var deadlineTextfieldLabel: DOOLabel = {
+        let label = DOOLabel(
+            font: .pretendard(.body3_medi),
+            color: .gray200,
+            alignment: .left,
+            padding: UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
+        )
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(selectEndDate))
+        label.backgroundColor = .white000
+        label.layer.borderColor = UIColor.gray200.cgColor
+        label.layer.cornerRadius = 6
+        label.layer.borderWidth = 1
+        label.isUserInteractionEnabled = true
+        label.addGestureRecognizer(gesture)
+        return label
+    }()
+    lazy var dropdownButton: UIButton = {
+        let btn = UIButton()
+        btn.setImage(ImageLiterals.ToDo.disabledDropdown, for: .normal)
+        btn.backgroundColor = .white000
+        btn.addTarget(self, action: #selector(selectEndDate), for: .touchUpInside)
+        return btn
+    }()
+    
+    
+    weak var delegate: EndDateViewDelegate?
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
     }
-    */
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setInquiryEndDateStyle() {
+        deadlineTextfieldLabel.layer.borderColor = UIColor.gray700.cgColor
+        deadlineTextfieldLabel.textColor = .gray700
+        dropdownButton.setImage(ImageLiterals.ToDo.enabledDropdown, for: .normal)
+    }
+    
+    @objc
+    func selectEndDate() {
+        self.delegate?.presentToDatePicker()
+    }
+    
+}
 
+private extension EndDateView {
+    
+    func setHierarchy() {
+        self.addSubviews(deadlineLabel, deadlineTextfieldLabel)
+        deadlineTextfieldLabel.addSubview(dropdownButton)
+    }
+    
+    func setLayout() {
+        deadlineLabel.snp.makeConstraints{
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(23))
+        }
+        deadlineTextfieldLabel.snp.makeConstraints{
+            $0.top.equalTo(deadlineLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(48))
+        }
+        dropdownButton.snp.makeConstraints{
+            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(12))
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(ScreenUtils.getHeight(22))
+        }
+    }
+    
 }

--- a/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
+++ b/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
@@ -18,6 +18,7 @@ class MemoTextView: UIView {
         color: .gray700,
         text: StringLiterals.ToDo.memo
     )
+    
     let memoTextView: UITextView = {
         let tv = UITextView()
         tv.backgroundColor = .white000
@@ -34,11 +35,13 @@ class MemoTextView: UIView {
         tv.layer.borderWidth = 1
         return tv
     }()
+   
     private let countMemoCharacterLabel = DOOLabel(
         font: .pretendard(.detail2_regular),
         color: .gray200,
         text: "0/1000"
     )
+    
     private let memoWarningLabel: DOOLabel = {
         let label = DOOLabel(font: .pretendard(.body3_medi), color: .red400)
         label.isHidden = true
@@ -47,7 +50,9 @@ class MemoTextView: UIView {
     
     
     var memoTextViewCount: Int = 0
+    
     var memoTextviewPlaceholder: String = ""
+    
     weak var delegate: MemoTextViewDelegate?
 
     override init(frame: CGRect) {
@@ -87,15 +92,18 @@ private extension MemoTextView {
             $0.top.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(24))
         }
+       
         memoTextView.snp.makeConstraints{
             $0.top.equalTo(memoLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(140))
         }
+        
         countMemoCharacterLabel.snp.makeConstraints{
             $0.top.equalTo(memoTextView.snp.bottom).offset(4)
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(4))
         }
+        
         memoWarningLabel.snp.makeConstraints {
             $0.top.equalTo(memoTextView.snp.bottom).offset(4)
             $0.leading.equalTo(memoTextView.snp.leading).offset(4)

--- a/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
+++ b/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
@@ -7,14 +7,172 @@
 
 import UIKit
 
+protocol MemoTextViewDelegate: AnyObject {
+    func checkMemoState()
+}
+
 class MemoTextView: UIView {
+    
+    private let memoLabel = DOOLabel(
+        font: .pretendard(.body2_bold),
+        color: .gray700,
+        text: StringLiterals.ToDo.memo
+    )
+    let memoTextView: UITextView = {
+        let tv = UITextView()
+        tv.backgroundColor = .white000
+        tv.textContainerInset = UIEdgeInsets(
+            top: ScreenUtils.getHeight(12),
+            left: ScreenUtils.getWidth(12),
+            bottom: ScreenUtils.getHeight(12),
+            right: ScreenUtils.getWidth(12)
+        )
+        tv.font = .pretendard(.body3_medi)
+        tv.textColor = .gray200
+        tv.layer.borderColor = UIColor.gray200.cgColor
+        tv.layer.cornerRadius = 6
+        tv.layer.borderWidth = 1
+        return tv
+    }()
+    private let countMemoCharacterLabel = DOOLabel(
+        font: .pretendard(.detail2_regular),
+        color: .gray200,
+        text: "0/1000"
+    )
+    private let memoWarningLabel: DOOLabel = {
+        let label = DOOLabel(font: .pretendard(.body3_medi), color: .red400)
+        label.isHidden = true
+        return label
+    }()
+    
+    
+    var memoTextViewCount: Int = 0
+    var memoTextviewPlaceholder: String = ""
+    weak var delegate: MemoTextViewDelegate?
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+        setDelegate()
     }
-    */
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setInquiryMemoStyle() {
+        guard let memotext = memoTextView.text?.count else {return}
+        memoTextView.layer.borderColor = memoTextView.text == "" ? UIColor.gray200.cgColor : UIColor.gray700.cgColor
+        memoTextView.textColor = memoTextView.text == "" ? UIColor.gray200 : UIColor.gray700
+        countMemoCharacterLabel.text = "\(memotext)/1000"
+        countMemoCharacterLabel.textColor = memoTextView.text == "" ? UIColor.gray200 : .gray700
+    }
 
+}
+
+private extension MemoTextView {
+    
+    func setHierarchy() {
+        self.addSubviews(memoLabel,
+                         memoTextView,
+                         memoWarningLabel,
+                         countMemoCharacterLabel
+        )
+    }
+    
+    func setLayout() {
+        memoLabel.snp.makeConstraints{
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(24))
+        }
+        memoTextView.snp.makeConstraints{
+            $0.top.equalTo(memoLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(140))
+        }
+        countMemoCharacterLabel.snp.makeConstraints{
+            $0.top.equalTo(memoTextView.snp.bottom).offset(4)
+            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(4))
+        }
+        memoWarningLabel.snp.makeConstraints {
+            $0.top.equalTo(memoTextView.snp.bottom).offset(4)
+            $0.leading.equalTo(memoTextView.snp.leading).offset(4)
+        }
+    }
+    
+    func setDelegate() {
+        memoTextView.delegate = self
+    }
+    
+    func memoTextViewBlankCheck() {
+        guard let textEmpty = memoTextView.text?.isEmpty else { return }
+        if textEmpty {
+            memoTextView.layer.borderColor = UIColor.gray200.cgColor
+            self.countMemoCharacterLabel.textColor = .gray200
+        } else {
+            memoTextView.layer.borderColor = UIColor.gray700.cgColor
+            self.countMemoCharacterLabel.textColor = .gray400
+        }
+    }
+    
+    func textViewCountCheck() {
+        
+        guard let text = memoTextView.text else { return }
+        
+        if text.count > 1000 {
+            memoTextView.layer.borderColor = UIColor.red500.cgColor
+            countMemoCharacterLabel.textColor = .red500
+            memoWarningLabel.text = "메모는 1000자를 초과할 수 없습니다."
+            memoWarningLabel.isHidden = false
+        } else {
+            memoWarningLabel.isHidden = true
+            
+        }
+    }
+}
+
+extension MemoTextView: UITextViewDelegate {
+    
+    func textViewDidBeginEditing (_ textView: UITextView) {
+        textView.becomeFirstResponder()
+        
+        if textView.text == memoTextviewPlaceholder {
+            textView.text = ""
+            textView.textColor = .gray700
+        }
+        textViewCountCheck()
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if let char = text.cString(using: String.Encoding.utf8) {
+            let isBackSpace = strcmp(char, "\\b")
+            if isBackSpace == -92 {
+                return true
+            }
+        }
+        
+        return true
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = memoTextviewPlaceholder
+            textView.textColor = .gray200
+            textViewCountCheck()
+        }
+        
+        
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        if textView == memoTextView {
+            let memoTextViewCount = textView.text.count
+            countMemoCharacterLabel.text = "\(memoTextViewCount)/1000"
+            memoTextViewBlankCheck()
+            textViewCountCheck()
+            self.delegate?.checkMemoState()
+        }
+    }
 }

--- a/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
+++ b/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
@@ -1,0 +1,20 @@
+//
+//  MemoTextView.swift
+//  Going-iOS
+//
+//  Created by 윤희슬 on 1/24/24.
+//
+
+import UIKit
+
+class MemoTextView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
+++ b/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
@@ -128,7 +128,6 @@ private extension MemoTextView {
             memoWarningLabel.isHidden = false
         } else {
             memoWarningLabel.isHidden = true
-            
         }
     }
 }
@@ -152,7 +151,6 @@ extension MemoTextView: UITextViewDelegate {
                 return true
             }
         }
-        
         return true
     }
     
@@ -162,8 +160,6 @@ extension MemoTextView: UITextViewDelegate {
             textView.textColor = .gray200
             textViewCountCheck()
         }
-        
-        
     }
     
     func textViewDidChange(_ textView: UITextView) {

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -32,12 +32,19 @@ class ToDoManagerView: UIView {
     }()
 
     var fromOurTodoParticipants: [Participant] = []
+    
     var allocators: [Allocators] = []
+    
     var beforeVC: String = ""
+    
     var navigationBarTitle: String = ""
+    
     var isActivateView: Bool = true
+    
     var isSecret: Bool = false
+    
     weak var delegate: ToDoManagerViewDelegate?
+    
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -82,6 +89,7 @@ private extension ToDoManagerView {
             $0.top.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(23))
         }
+        
         todoManagerCollectionView.snp.makeConstraints{
             $0.top.equalTo(managerLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
             $0.leading.trailing.equalToSuperview()

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -7,7 +7,11 @@
 
 import UIKit
 
-class ToDoManagerCollectionView: UIView {
+protocol ToDoManagerViewDelegate: AnyObject {
+    func tapToDoManagerButton(_ sender: UIButton)
+}
+
+class ToDoManagerView: UIView {
 
     private let managerLabel: UILabel = DOOLabel(
         font: .pretendard(.body2_bold),
@@ -23,7 +27,223 @@ class ToDoManagerCollectionView: UIView {
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.showsVerticalScrollIndicator = false
         collectionView.isScrollEnabled = false
+        collectionView.register(ToDoManagerCollectionViewCell.self, forCellWithReuseIdentifier: ToDoManagerCollectionViewCell.identifier)
         return collectionView
     }()
 
+    var fromOurTodoParticipants: [Participant] = []
+    var allocators: [Allocators] = []
+    var beforeVC: String = ""
+    var navigationBarTitle: String = ""
+    var isActivateView: Bool = true
+    var isSecret: Bool = false
+    weak var delegate: ToDoManagerViewDelegate?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+        setDelegate()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// 담당자 버튼 클릭 시 버튼 스타일 변경해주는 메소드
+    func changeButtonConfig(isSelected: Bool, btn: UIButton) {
+        if !isSelected {
+            btn.setTitleColor(.white000, for: .normal)
+            btn.backgroundColor = btn.tag == 0 ? UIColor.red500 : UIColor.gray400
+            btn.layer.borderColor = btn.tag == 0 ? UIColor.red500.cgColor : UIColor.gray400.cgColor
+        }else {
+            btn.setTitleColor(.gray300, for: .normal)
+            btn.backgroundColor = .white000
+            btn.layer.borderColor = UIColor.gray300.cgColor
+        }
+    }
+    
+    // 담당자 버튼 탭 시 버튼 색상 변경 & 배열에 담아주는 메서드
+    @objc
+    func didTapToDoManagerButton(_ sender: UIButton) {
+        self.delegate?.tapToDoManagerButton(sender)
+    }
+}
+
+private extension ToDoManagerView {
+    
+    func setHierarchy() {
+        self.addSubviews(managerLabel, todoManagerCollectionView)
+    }
+    
+    func setLayout() {
+        managerLabel.snp.makeConstraints{
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(23))
+        }
+        todoManagerCollectionView.snp.makeConstraints{
+            $0.top.equalTo(managerLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(24))
+        }
+    }
+    
+    func setDelegate() {
+        todoManagerCollectionView.delegate = self
+        todoManagerCollectionView.dataSource = self
+    }
+
+}
+
+
+// MARK: - Extension
+
+extension ToDoManagerView: UICollectionViewDataSource{
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        // 마이투두 - 할일추가 - 1로 픽스
+        
+        if beforeVC == "our" {
+            if navigationBarTitle == "추가" {
+                return self.fromOurTodoParticipants.count
+            } else {
+                return self.allocators.count
+            }
+        }
+        else {
+            return self.allocators.count
+        }
+    }
+    
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        guard let managerCell = collectionView.dequeueReusableCell(withReuseIdentifier: ToDoManagerCollectionViewCell.identifier, for: indexPath) as? ToDoManagerCollectionViewCell else {return UICollectionViewCell()}
+        
+        var name = ""
+        if beforeVC == "our" {
+            if navigationBarTitle == "추가" {
+                name = fromOurTodoParticipants[indexPath.row].name
+            } else {
+                name = allocators[indexPath.row].name
+            }
+        } else {
+            name = allocators[indexPath.row].name
+        }
+        
+        managerCell.managerButton.isEnabled = true
+        managerCell.managerButton.setTitle(name, for: .normal)
+        managerCell.managerButton.tag = indexPath.row
+        managerCell.managerButton.addTarget(self, action: #selector(didTapToDoManagerButton(_:)), for: .touchUpInside)
+        //아워투두 -> 조회
+        //다 선택된 옵션
+        //마이투두 -> 조회
+        //혼자할일 + 라벨
+        //아워투두
+        if beforeVC == "our" {
+            //조회
+            if isActivateView == false {
+                managerCell.managerButton.isSelected = true
+                managerCell.managerButton.setTitleColor(.white000, for: .normal)
+                if allocators[indexPath.row].isOwner {
+                    managerCell.managerButton.backgroundColor = .red500
+                    managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
+                } else {
+                    managerCell.managerButton.backgroundColor = .gray400
+                    managerCell.managerButton.layer.borderColor = UIColor.gray400.cgColor
+                }
+            } // 추가
+            else {
+                managerCell.managerButton.backgroundColor = .white000
+                managerCell.managerButton.setTitleColor(.gray300, for: .normal)
+                managerCell.managerButton.layer.borderColor = UIColor.gray300.cgColor
+            }
+        }// 마이투두
+        else {
+            // 조회
+            if isActivateView == false {
+                managerCell.managerButton.isSelected = true
+                // 혼자 할 일
+                if self.isSecret == true {
+                    //설명라벨 세팅
+                    if allocators[indexPath.row].name == "나만 볼 수 있는 할일이에요" {
+                        managerCell.managerButton.isEnabled = false
+                        managerCell.managerButton.backgroundColor = .white000
+                        managerCell.managerButton.layer.borderColor = UIColor.white000.cgColor
+                        
+                        managerCell.managerButton.setTitleColor(.gray200, for: .normal)
+                    } else {
+                        managerCell.managerButton.setImage(ImageLiterals.ToDo.orangeLock, for: .normal)
+                        managerCell.managerButton.setTitleColor(.red500, for: .normal)
+                        managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
+                        managerCell.managerButton.backgroundColor = .white000
+                    }
+                } else{
+                    managerCell.managerButton.setTitleColor(.white000, for: .normal)
+                    if allocators[indexPath.row].isOwner { //owner
+                        managerCell.managerButton.backgroundColor = UIColor.red500
+                        managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
+                    }else {
+                        managerCell.managerButton.backgroundColor = UIColor.gray400
+                        managerCell.managerButton.layer.borderColor = UIColor.gray400.cgColor
+                    }
+                }
+            }// 추가
+            else {
+                //설명라벨 세팅
+                if allocators[indexPath.row].name == "나만 볼 수 있는 할일이에요" {
+                    managerCell.managerButton.isEnabled = true
+                    managerCell.managerButton.backgroundColor = .white000
+                    managerCell.managerButton.layer.borderColor = UIColor.white000.cgColor
+                    managerCell.managerButton.setTitleColor(.white000, for: .normal)
+                } else {
+                    managerCell.managerButton.setImage(ImageLiterals.ToDo.orangeLock, for: .normal)
+                    managerCell.managerButton.setTitleColor(.red500, for: .normal)
+                    managerCell.managerButton.layer.borderColor = UIColor.red500.cgColor
+                    managerCell.managerButton.backgroundColor = .white000
+                    managerCell.managerButton.isUserInteractionEnabled = false
+                }
+            }
+        }
+        return managerCell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+    }
+}
+
+extension ToDoManagerView: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return ScreenUtils.getWidth(3)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return ScreenUtils.getWidth(3)
+    }
+    
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+                
+        if beforeVC == "my" {
+            if navigationBarTitle == "추가" {
+               return CGSize(width: ScreenUtils.getWidth(66), height: ScreenUtils.getHeight(20))
+                
+            //조회
+            } else {
+                if self.isSecret == true {
+                    if indexPath.row == 0 {
+                        return CGSize(width: ScreenUtils.getWidth(66), height: ScreenUtils.getHeight(20))
+                    } else {
+                        return CGSize(width: ScreenUtils.getWidth(140), height: ScreenUtils.getHeight(18))
+                    }
+                } else {
+                    return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
+                    
+                }
+            }
+        }
+        return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
+    }
 }

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -207,10 +207,6 @@ extension ToDoManagerView: UICollectionViewDataSource{
         }
         return managerCell
     }
-    
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
-    }
 }
 
 extension ToDoManagerView: UICollectionViewDelegateFlowLayout {

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -1,0 +1,29 @@
+//
+//  ToDoManagerCollectionView.swift
+//  Going-iOS
+//
+//  Created by 윤희슬 on 1/24/24.
+//
+
+import UIKit
+
+class ToDoManagerCollectionView: UIView {
+
+    private let managerLabel: UILabel = DOOLabel(
+        font: .pretendard(.body2_bold),
+        color: .gray700, 
+        text: StringLiterals.ToDo.allocation
+    )
+    
+    let todoManagerCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.isScrollEnabled = false
+        return collectionView
+    }()
+
+}

--- a/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
@@ -7,14 +7,167 @@
 
 import UIKit
 
+import SnapKit
+
+protocol ToDoTextFieldDelegate: AnyObject {
+    func todoTextFieldDidChange()
+    func checkTextFieldState()
+}
+
 class ToDoTextFieldView: UIView {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
-    }
-    */
+    private let todoLabel = DOOLabel(
+        font: .pretendard(.body2_bold),
+        color: .gray700,
+        text: StringLiterals.ToDo.todo
+    )
+    lazy var todoTextfield: UITextField = {
+        let tf = UITextField()
+        tf.setTextField(forPlaceholder: "", forBorderColor: .gray200, forCornerRadius: 6)
+        tf.font = .pretendard(.body3_medi)
+        tf.setPlaceholderColor(.gray700)
+        tf.textColor = .gray700
+        tf.backgroundColor = .white000
+        tf.setLeftPadding(amount: 12)
+        tf.addTarget(self, action: #selector(todoTextFieldChange), for: .editingChanged)
+        return tf
+    }()
+    private let warningLabel: DOOLabel = {
+        let label = DOOLabel(font: .pretendard(.body3_medi), color: .red400)
+        label.isHidden = true
+        return label
+    }()
+    lazy var countToDoCharacterLabel = DOOLabel(
+        font: .pretendard(.detail2_regular),
+        color: .gray200,
+        text: "0/15"
+    )
+    
+    
+    weak var delegate: ToDoTextFieldDelegate?
+    var todoTextFieldCount: Int = 0
+    private var isTodoTextFieldGood: Bool = false
+    var todoTextfieldPlaceholder: String = ""
 
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+        setDelegate()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setInquiryTextFieldStyle() {
+        guard let todotext = todoTextfield.placeholder?.count else {return}
+        todoTextfield.layer.borderColor = UIColor.gray700.cgColor
+        todoTextfield.setPlaceholderColor(.gray700)
+        countToDoCharacterLabel.textColor = .gray700
+        countToDoCharacterLabel.text = "\(todotext)/15"
+    }
+
+    
+    func todoTextFieldCheck() {
+        guard let text = todoTextfield.text else { return }
+        
+        if text.count > 15 {
+            todoTextfield.layer.borderColor = UIColor.red500.cgColor
+            countToDoCharacterLabel.textColor = .red500
+            warningLabel.text = "내용은 15자 이하여야 합니다"
+            warningLabel.isHidden = false
+            self.isTodoTextFieldGood = false
+            
+        } else if text.count == 0 {
+            todoTextfield.layer.borderColor = UIColor.gray200.cgColor
+            countToDoCharacterLabel.textColor = .gray200
+            warningLabel.isHidden = true
+            self.isTodoTextFieldGood = false
+            
+        } else if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            self.isTodoTextFieldGood = false
+            
+            todoTextfield.layer.borderColor = UIColor.red500.cgColor
+            countToDoCharacterLabel.textColor = .red500
+            warningLabel.text = "내용에는 공백만 입력할 수 없어요"
+            warningLabel.isHidden = false
+        }  else {
+            todoTextfield.layer.borderColor = UIColor.gray700.cgColor
+            countToDoCharacterLabel.textColor = .gray700
+            warningLabel.isHidden = true
+            self.isTodoTextFieldGood = true
+        }
+        
+        countToDoCharacterLabel.text = "\(text.count)/15"
+        self.delegate?.checkTextFieldState()
+    }
+    
+    @objc
+    func todoTextFieldChange() {
+        self.delegate?.todoTextFieldDidChange()
+    }
+    
+}
+
+private extension ToDoTextFieldView {
+    
+    func setHierarchy() {
+        self.addSubviews(todoLabel, todoTextfield, warningLabel ,countToDoCharacterLabel)
+    }
+    
+    func setLayout() {
+        todoLabel.snp.makeConstraints{
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(23))
+        }
+        todoTextfield.snp.makeConstraints{
+            $0.top.equalTo(todoLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(ScreenUtils.getHeight(48))
+        }
+        warningLabel.snp.makeConstraints {
+            $0.top.equalTo(todoTextfield.snp.bottom).offset(4)
+            $0.leading.equalTo(todoTextfield.snp.leading).offset(4)
+        }
+        countToDoCharacterLabel.snp.makeConstraints{
+            $0.top.equalTo(todoTextfield.snp.bottom).offset(4)
+            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(4))
+        }
+    }
+    
+    func setDelegate() {
+        
+    }
+}
+
+extension ToDoTextFieldView: UITextFieldDelegate {
+    func textFieldDidBeginEditing (_ textField: UITextField) {
+        self.delegate?.checkTextFieldState()
+        todoTextFieldCheck()
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        todoTextFieldCheck()
+        self.delegate?.checkTextFieldState()
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if let char = string.cString(using: String.Encoding.utf8) {
+            let isBackSpace = strcmp(char, "\\b")
+            if isBackSpace == -92 {
+                return true
+            }
+        }
+        return true
+    }
+    
+    /// 엔터 키 누르면 키보드 내리는 메서드
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
 }

--- a/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
@@ -55,7 +55,6 @@ class ToDoTextFieldView: UIView {
         
         setHierarchy()
         setLayout()
-        setDelegate()
     }
     
     required init?(coder: NSCoder) {
@@ -137,10 +136,6 @@ private extension ToDoTextFieldView {
             $0.top.equalTo(todoTextfield.snp.bottom).offset(4)
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(4))
         }
-    }
-    
-    func setDelegate() {
-        
     }
 }
 

--- a/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
@@ -21,6 +21,7 @@ class ToDoTextFieldView: UIView {
         color: .gray700,
         text: StringLiterals.ToDo.todo
     )
+    
     lazy var todoTextfield: UITextField = {
         let tf = UITextField()
         tf.setTextField(forPlaceholder: "", forBorderColor: .gray200, forCornerRadius: 6)
@@ -32,11 +33,13 @@ class ToDoTextFieldView: UIView {
         tf.addTarget(self, action: #selector(todoTextFieldChange), for: .editingChanged)
         return tf
     }()
+    
     private let warningLabel: DOOLabel = {
         let label = DOOLabel(font: .pretendard(.body3_medi), color: .red400)
         label.isHidden = true
         return label
     }()
+    
     lazy var countToDoCharacterLabel = DOOLabel(
         font: .pretendard(.detail2_regular),
         color: .gray200,
@@ -45,8 +48,11 @@ class ToDoTextFieldView: UIView {
     
     
     weak var delegate: ToDoTextFieldDelegate?
+    
     var todoTextFieldCount: Int = 0
+    
     private var isTodoTextFieldGood: Bool = false
+    
     var todoTextfieldPlaceholder: String = ""
 
     
@@ -114,7 +120,10 @@ class ToDoTextFieldView: UIView {
 private extension ToDoTextFieldView {
     
     func setHierarchy() {
-        self.addSubviews(todoLabel, todoTextfield, warningLabel ,countToDoCharacterLabel)
+        self.addSubviews(todoLabel, 
+                         todoTextfield,
+                         warningLabel ,
+                         countToDoCharacterLabel)
     }
     
     func setLayout() {
@@ -123,15 +132,18 @@ private extension ToDoTextFieldView {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(23))
         }
+        
         todoTextfield.snp.makeConstraints{
             $0.top.equalTo(todoLabel.snp.bottom).offset(ScreenUtils.getHeight(8))
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(ScreenUtils.getHeight(48))
         }
+        
         warningLabel.snp.makeConstraints {
             $0.top.equalTo(todoTextfield.snp.bottom).offset(4)
             $0.leading.equalTo(todoTextfield.snp.leading).offset(4)
         }
+        
         countToDoCharacterLabel.snp.makeConstraints{
             $0.top.equalTo(todoTextfield.snp.bottom).offset(4)
             $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(4))

--- a/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
@@ -1,0 +1,20 @@
+//
+//  ToDoTextFieldView.swift
+//  Going-iOS
+//
+//  Created by 윤희슬 on 1/24/24.
+//
+
+import UIKit
+
+class ToDoTextFieldView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#194

👷 **작업한 내용**
- 할일 추가 뷰컨의 뷰들 분리
- 코드 레이아웃 수정

## 🚨 참고 사항

### 1. 뷰 분리
기존에는 UI 요소들을 별도의 뷰로 쪼개지 않아서 하나의 뷰컨에 있는 코드의 길이가 너무 길어진다는 문제가 있었습니다. 추후에 다른 세부 기능까지 더해지면 더더욱 복잡해 질 것 같아 UI 요소들을 별도의 뷰로 나누었습니다. 
할일 작성 관련 뷰 - TodoTextFieldView
마감일 선택 관련 뷰 - EndDateView
담당자 선택 관련 뷰 - ToDoManagerView
메모 작성 관련 뷰 - MemoTextView

```swift
    // ToDoViewController
    private let todoTextFieldView = ToDoTextFieldView()
    private let endDateView = EndDateView()
    private let bottomSheetVC = DatePickerBottomSheetViewController()
    private let todoManagerView = ToDoManagerView()
    private let memoTextView = MemoTextView()
```


## 📟 관련 이슈
- Resolved: #194 
