### PR TITLE
[FEAT] 성향테스트스플래쉬뷰 스킵 버튼 추가 (#206)

### DIFF
--- a/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
+++ b/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
@@ -66,8 +66,8 @@ final class UserTestSplashViewController: UIViewController {
 private extension UserTestSplashViewController {
     func hideTabbar() {
         self.navigationController?.tabBarController?.tabBar.isHidden = true
-
     }
+    
     func setHierarchy() {
         view.addSubviews(userTestSplashImageView, titleLabel, subTitleLabel, skipButton, nextButton)
     }
@@ -90,7 +90,7 @@ private extension UserTestSplashViewController {
         }
         
         skipButton.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(182)
+            $0.bottom.equalTo(nextButton.snp.top).offset(-20)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(ScreenUtils.getWidth(78))
         }

--- a/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
+++ b/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
@@ -30,11 +30,21 @@ final class UserTestSplashViewController: UIViewController {
                                       numberOfLine: 2,
                                       alignment: .center
                                       )
+    
+    private lazy var skipButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("테스트 건너뛰기", for: .normal)
+        button.setTitleColor(UIColor(resource: .gray300), for: .normal)
+        button.titleLabel?.font = .pretendard(.detail2_regular)
+        button.setUnderline()
+        button.addTarget(self, action: #selector(skipButtonTapped), for: .touchUpInside)
+        return button
+    }()
   
     private lazy var nextButton: UIButton = {
         let button = UIButton()
         button.setTitle("테스트 시작하기", for: .normal)
-        button.titleLabel?.textColor = UIColor(resource: .white000)
+        button.setTitleColor(UIColor(resource: .white000), for: .normal)
         button.titleLabel?.font = .pretendard(.body1_bold)
         button.backgroundColor = UIColor(resource: .gray500)
         button.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
@@ -59,7 +69,7 @@ private extension UserTestSplashViewController {
 
     }
     func setHierarchy() {
-        view.addSubviews(userTestSplashImageView, titleLabel, subTitleLabel ,nextButton)
+        view.addSubviews(userTestSplashImageView, titleLabel, subTitleLabel, skipButton, nextButton)
     }
     
     func setLayout() {
@@ -79,6 +89,12 @@ private extension UserTestSplashViewController {
             $0.centerX.equalToSuperview()
         }
         
+        skipButton.snp.makeConstraints {
+            $0.top.equalTo(subTitleLabel.snp.bottom).offset(182)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(ScreenUtils.getWidth(78))
+        }
+        
         nextButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
@@ -92,6 +108,11 @@ private extension UserTestSplashViewController {
     
     @objc func nextButtonTapped() {
         let nextVC = UserTestViewController()
+        self.navigationController?.pushViewController(nextVC, animated: true)
+    }
+    
+    @objc func skipButtonTapped() {
+        let nextVC = DashBoardViewController()
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }

--- a/Going-iOS/Scene/UserTestResult/Views/TestResultTicketView.swift
+++ b/Going-iOS/Scene/UserTestResult/Views/TestResultTicketView.swift
@@ -49,7 +49,7 @@ final class TestResultTicketView: UIView {
         return stack
     }()
     
-    let titleLabel = DOOLabel(font: .pretendard(.detail2_bold), color: UIColor(resource: .gray700), numberOfLine: 2, alignment: .center)
+    let titleLabel = DOOLabel(font: .pretendard(.detail1_bold), color: UIColor(resource: .gray700), numberOfLine: 2, alignment: .center)
     
     private let descStackView: UIStackView = {
         let stack = UIStackView()
@@ -59,9 +59,9 @@ final class TestResultTicketView: UIView {
         return stack
     }()
     
-    lazy var firstDescLabel = DOOLabel(font: .pretendard(.detail3_regular), color: UIColor(resource: .gray700), numberOfLine: 2)
-    lazy var secondDescLabel = DOOLabel(font: .pretendard(.detail3_regular), color: UIColor(resource: .gray700), numberOfLine: 2)
-    lazy var thirdDescLabel = DOOLabel(font: .pretendard(.detail3_regular), color: UIColor(resource: .gray700), numberOfLine: 2)
+    lazy var firstDescLabel = DOOLabel(font: .pretendard(.detail2_regular), color: UIColor(resource: .gray700), numberOfLine: 2)
+    lazy var secondDescLabel = DOOLabel(font: .pretendard(.detail2_regular), color: UIColor(resource: .gray700), numberOfLine: 2)
+    lazy var thirdDescLabel = DOOLabel(font: .pretendard(.detail2_regular), color: UIColor(resource: .gray700), numberOfLine: 2)
     
     override init(frame: CGRect) {
         super.init(frame: frame)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- #206

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 성향테스트스플래쉬뷰 스킵버튼 추가
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 이미 성향테스트를 한 후에 스킵을 할 경우와 처음에 스킵을 한 후 스플래시에서 경우에 따른 분기처리를 서버와 상의해야됨.
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 15 Pro - 2024-03-01 at 18 04 53](https://github.com/Team-Going/Going-iOS/assets/70939232/ebc6c381-004d-4345-9936-066feb5698da)



|기능|스크린샷|
|:--:|:--:|
|아이폰13mini|![Simulator Screen Recording - iPhone 13 mini - 2024-03-01 at 17 59 12](https://github.com/Team-Going/Going-iOS/assets/70939232/bfaedbb3-4b13-455f-8c42-e7fb4e9614d8)



## 📟 관련 이슈
- Resolved: #206 
