### PR TITLE
[FEAT] 내여행프로필뷰와 내프로필수정 뷰연결, 성향테스트 안했을때 서버통신분기처리, 성향테스트엠티뷰 (#230)

### DIFF
--- a/Going-iOS/Scene/DashBoard/ViewControllers/DashBoardViewController.swift
+++ b/Going-iOS/Scene/DashBoard/ViewControllers/DashBoardViewController.swift
@@ -79,6 +79,8 @@ class DashBoardViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        UserDefaults.standard.set(false, forKey: "isFromMakeProfileVC")
+        
         setSegmentDidChange()
         setStyle()
         setHierarchy()

--- a/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
+++ b/Going-iOS/Scene/MakeProfile/ViewControllers/MakeProfileViewController.swift
@@ -124,7 +124,7 @@ final class MakeProfileViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        UserDefaults.standard.set(true, forKey: "isFromMakeProfileVC")
         setStyle()
         setHierarchy()
         setLayout()
@@ -217,6 +217,7 @@ private extension MakeProfileViewController {
     
     func setStyle() {
         self.view.backgroundColor = UIColor(resource: .white000)
+        
     }
     
     func setDelegate() {
@@ -339,7 +340,6 @@ private extension MakeProfileViewController {
             do {
                 try await AuthService.shared.postSignUp(token: token, signUpBody: signUpBody)
                 let nextVC = UserTestSplashViewController()
-                UserDefaults.standard.set(true, forKey: "isFromMakeProfileVC")
                 self.navigationController?.pushViewController(nextVC, animated: true)
             }
             catch {

--- a/Going-iOS/Scene/MyProfile/ViewControllers/ChangeMyProfileViewController.swift
+++ b/Going-iOS/Scene/MyProfile/ViewControllers/ChangeMyProfileViewController.swift
@@ -327,7 +327,7 @@ private extension ChangeMyProfileViewController {
             do {
                 try await ProfileService.shared.patchMyProfileData(myProfileData: signUpBody)
                 self.navigationController?.popViewController(animated: true)
-                DOOToast.show(message: "프로필을 수정했어요", insetFromBottom: 80)
+                DOOToast.show(message: "프로필을 수정했어요", insetFromBottom: 115)
             }
             catch {
                 guard let error = error as? NetworkError else { return }

--- a/Going-iOS/Scene/MyProfile/ViewControllers/MyProfileViewController.swift
+++ b/Going-iOS/Scene/MyProfile/ViewControllers/MyProfileViewController.swift
@@ -283,6 +283,11 @@ extension MyProfileViewController {
                 guard let testResultIndex else { return }
                 if self.testResultIndex != -1 {
                     self.testResultData = UserTypeTestResultAppData.dummy()[testResultIndex]
+                    self.resultImageView.isHidden = false
+                    self.myResultView.isHidden = false
+                    self.emptyUserTestView.isHidden = true
+                    self.myProfileScrollView.isScrollEnabled = true
+                    self.doUserTestButton.isHidden = true
                 } else {
                     setEmptyViewCase()
                 }
@@ -328,7 +333,7 @@ extension MyProfileViewController: TestResultViewDelegate {
     func backToTestButton() {
         let nextVC = UserTestSplashViewController()
         UserDefaults.standard.set(false, forKey: "isFromMakeProfileVC")
-        self.navigationController?.pushViewController(nextVC, animated: false)
+        self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }
 

--- a/Going-iOS/Scene/MyProfile/ViewControllers/MyProfileViewController.swift
+++ b/Going-iOS/Scene/MyProfile/ViewControllers/MyProfileViewController.swift
@@ -23,6 +23,8 @@ final class MyProfileViewController: UIViewController {
         }
     }
     
+    private let emptyUserTestView = EmptyUserTestView()
+    
     private var testResultIndex: Int?
     
     // MARK: - UI Properties
@@ -71,6 +73,13 @@ final class MyProfileViewController: UIViewController {
         return view
     }()
     
+    private lazy var doUserTestButton: DOOButton = {
+        let btn = DOOButton(type: .enabled, title: "여행 캐릭터 검사하러 가기")
+        btn.addTarget(self, action: #selector(doUserTestButtonTapped), for: .touchUpInside)
+        btn.isHidden = true
+        return btn
+    }()
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -104,20 +113,32 @@ private extension MyProfileViewController {
         contentView.backgroundColor = UIColor(resource: .white000)
         view.backgroundColor = UIColor(resource: .white000)
         self.myProfileScrollView.showsVerticalScrollIndicator = false
+        self.emptyUserTestView.isHidden = true
+    }
+    
+    func setEmptyViewCase() {
+        self.resultImageView.isHidden = true
+        self.myResultView.isHidden = true
+        self.emptyUserTestView.isHidden = false
+        self.myProfileScrollView.isScrollEnabled = false
+        self.doUserTestButton.isHidden = false
+        self.myProfileTopView.profileImageView.image = UIImage(resource: .imgProfileGuest)
     }
     
     func setHierarchy() {
-        view.addSubviews(navigationBar, 
-                         naviUnderLineView, 
-                         myProfileScrollView)
+        view.addSubviews(navigationBar,
+                         naviUnderLineView,
+                         myProfileScrollView,
+                         doUserTestButton)
         
         navigationBar.addSubview(saveButton)
         
         myProfileScrollView.addSubviews(contentView)
         
-        contentView.addSubviews(myProfileTopView, 
+        contentView.addSubviews(myProfileTopView,
                                 resultImageView,
-                                myResultView)
+                                myResultView,
+                                emptyUserTestView)
     }
     
     func setLayout() {
@@ -155,6 +176,11 @@ private extension MyProfileViewController {
             $0.height.equalTo(ScreenUtils.getHeight(109))
         }
         
+        emptyUserTestView.snp.makeConstraints {
+            $0.top.equalTo(myProfileTopView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
         resultImageView.snp.makeConstraints {
             $0.top.equalTo(myProfileTopView.snp.bottom)
             $0.height.equalTo(228)
@@ -165,6 +191,13 @@ private extension MyProfileViewController {
             $0.top.equalTo(resultImageView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
+        }
+        
+        doUserTestButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-6)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(Constant.Screen.width - 48)
+            $0.height.equalTo(ScreenUtils.getHeight(50))
         }
     }
     
@@ -199,6 +232,14 @@ private extension MyProfileViewController {
     @objc
     func saveImageButtonTapped() {
         checkAccess()
+    }
+    
+    //성향테스트안했을 때, 성향테스트스플래시로 보내줌
+    @objc
+    func doUserTestButtonTapped() {
+        let nextVC = UserTestSplashViewController()
+        UserDefaults.standard.set(false, forKey: "isFromMakeProfileVC")
+        self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }
 
@@ -239,8 +280,12 @@ extension MyProfileViewController {
                 self.myProfileTopView.userDescriptionLabel.text = profileData.intro
                 self.myProfileTopView.userNameLabel.text = profileData.name
                 
-                guard let index = testResultIndex else { return }
-                self.testResultData = UserTypeTestResultAppData.dummy()[index]
+                guard let testResultIndex else { return }
+                if self.testResultIndex != -1 {
+                    self.testResultData = UserTypeTestResultAppData.dummy()[testResultIndex]
+                } else {
+                    setEmptyViewCase()
+                }
             }
             catch {
                 guard let error = error as? NetworkError else { return }

--- a/Going-iOS/Scene/MyProfile/ViewControllers/MyTravelProfileViewController.swift
+++ b/Going-iOS/Scene/MyProfile/ViewControllers/MyTravelProfileViewController.swift
@@ -157,6 +157,7 @@ private extension MyTravelProfileViewController {
     func setDelegate() {
         userTestResultScrollView.myResultView.delegate = self
         travelTestResultView.delegate = self
+        myProfileTopView.delegate = self
     }
     
     func setSegmentDidChange() {
@@ -356,5 +357,14 @@ extension MyTravelProfileViewController {
                 handleError(error)
             }
         }
+    }
+}
+
+extension MyTravelProfileViewController: MyProfileTopViewDelegate {
+    func changeMyProfileButtonTapped() {
+        let nextVC = ChangeMyProfileViewController()
+        nextVC.nameTextField.text = myProfileTopView.userNameLabel.text
+        nextVC.descTextField.text = myProfileTopView.userDescriptionLabel.text
+        self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }

--- a/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
+++ b/Going-iOS/Scene/UserTest/ViewControllers/UserTestSplashViewController.swift
@@ -127,8 +127,8 @@ private extension UserTestSplashViewController {
         if UserDefaults.standard.bool(forKey: "isFromMakeProfileVC") == false {
             self.navigationController?.popViewController(animated: true)
         } else {
-            let nextVC = DashBoardViewController()
-            self.navigationController?.pushViewController(nextVC, animated: true)
+            self.view.window?.rootViewController = UINavigationController(rootViewController: DashBoardViewController())
+            self.view.window?.makeKeyAndVisible()
         }
     }
 }

--- a/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
+++ b/Going-iOS/Scene/UserTestResult/ViewControllers/UserTestResultViewController.swift
@@ -189,6 +189,9 @@ private extension UserTestResultViewController {
     @objc
     func nextButtonTapped() {
         
+        self.view.window?.rootViewController = UINavigationController(rootViewController: DashBoardViewController())
+        self.view.window?.makeKeyAndVisible()
+        
         if UserDefaults.standard.bool(forKey: "isFromMakeProfileVC") == false {
             
             guard let viewControllerStack = self.navigationController?.viewControllers else { return }
@@ -294,7 +297,6 @@ extension UserTestResultViewController: ViewControllerServiceable {
 
 extension UserTestResultViewController: TestResultViewDelegate {
     func backToTestButton() {
-        
         // 뷰 스택에서 UserTestSplashViewController를 찾아서 거기까지 pop
         guard let viewControllerStack = self.navigationController?.viewControllers else { return }
         for viewController in viewControllerStack {


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- #230 
## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 내여행프로필뷰와 내프로필수정 뷰연결 
- 성향테스트 안했을때 서버통신분기처리
- 성향테스트엠티뷰
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src = "" width ="250">|


|기능|스크린샷|
|:--:|:--:|
|아이폰13mini|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #230
