### PR TITLE
[FEAT] 여행성향테스트수정뷰 연결 구현 (#228)

### DIFF
--- a/Going-iOS/Scene/MyProfile/ViewControllers/MyTravelProfileViewController.swift
+++ b/Going-iOS/Scene/MyProfile/ViewControllers/MyTravelProfileViewController.swift
@@ -291,7 +291,7 @@ extension MyTravelProfileViewController: TravelTestResultViewDelegate {
     func userDidSelectAnswer() { return }
     
     func retryTravelTestButton() {
-        let vc = TravelTestViewController()
+        let vc = EditTravelTestViewController()
         vc.participantId = self.participantId
         vc.tripId = self.tripId
         self.navigationController?.pushViewController(vc, animated: false)

--- a/Going-iOS/Scene/MyProfile/ViewControllers/MyTravelProfileViewController.swift
+++ b/Going-iOS/Scene/MyProfile/ViewControllers/MyTravelProfileViewController.swift
@@ -30,6 +30,8 @@ final class MyTravelProfileViewController: UIViewController {
     
     lazy var participantId: Int = 0
     
+    var tripId: Int = 0
+    
     var isOwner: Bool = false
     
     var isEmpty: Bool = false
@@ -290,6 +292,8 @@ extension MyTravelProfileViewController: TravelTestResultViewDelegate {
     
     func retryTravelTestButton() {
         let vc = TravelTestViewController()
+        vc.participantId = self.participantId
+        vc.tripId = self.tripId
         self.navigationController?.pushViewController(vc, animated: false)
     }
 }

--- a/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
+++ b/Going-iOS/Scene/OurToDo/ViewControllers/OurToDoViewController.swift
@@ -538,7 +538,7 @@ extension OurToDoViewController: TripMiddleViewDelegate {
     func pushToMemberVC(participantId: Int) {
         let myTravelProfileVC = MyTravelProfileViewController()
         myTravelProfileVC.participantId = participantId
-        
+        myTravelProfileVC.tripId = self.tripId
         // 본인인 경우
         if self.ownerId == participantId {
             myTravelProfileVC.isOwner = true

--- a/Going-iOS/Scene/StartTravel/ViewControllers/EditTravelTestViewController.swift
+++ b/Going-iOS/Scene/StartTravel/ViewControllers/EditTravelTestViewController.swift
@@ -205,7 +205,7 @@ extension EditTravelTestViewController {
             do {
                 try await TravelDetailService.shared.patchTravelTest(tripId: tripId, requestBody: patchRequestBody)
             }
-            self.navigationController?.popToRootViewController(animated: false)
+            self.navigationController?.popViewController(animated: false)
             DOOToast.show(message: "취향태그를 수정했어요", insetFromBottom: ScreenUtils.getHeight(103))
         }
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- #228

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 여행성향테스트수정뷰 구현 전에 임의로 TravelTestVC로 연결되어 있던 부분 올바르게 변경해두었습니다.
- 스크린샷 확인 부탁드립니다!🌟

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
```swift
    // 취향 태그 결과값에 따라 버튼 색상 세팅하는 메소드
    func setStyleTagResultButton(result: Int) {
       answerButtons[result-1].backgroundColor = UIColor(resource: .gray400)
    }
```
여기서 유효하지 않은 index 로 중간에 멈추는데 같이 확인해보면 좋을 것 같습니다!

## 📸 스크린샷

https://github.com/Team-Going/Going-iOS/assets/102219161/7017c919-507f-44bb-8caa-3551addf67c9



## 📟 관련 이슈
- Resolved: #228 
