### PR TITLE
[FEAT] 1차 추가 QA 대응 (#253)

### DIFF
--- a/Going-iOS/Scene/Member/ViewControllers/MemberViewController.swift
+++ b/Going-iOS/Scene/Member/ViewControllers/MemberViewController.swift
@@ -40,6 +40,7 @@ final class MemberViewController: UIViewController {
         didSet {
             
             if memberData?.participants.count != 1 {
+                whiteBackgroundView.isHidden = true
                 
                 membersProfileCollectionView.reloadData()
                 
@@ -67,6 +68,7 @@ final class MemberViewController: UIViewController {
                     self.redTasteLabel.text = formattedText
                     self.grayTasteLabel.text = "에 대한 여행 취향이 잘 맞네요"
                 }
+                
             } else {
                 self.memberScrollView.isHidden = true
                 self.noFriendsEmptyView.isHidden = false

--- a/Going-iOS/Scene/Member/ViewControllers/MemberViewController.swift
+++ b/Going-iOS/Scene/Member/ViewControllers/MemberViewController.swift
@@ -30,13 +30,11 @@ final class MemberViewController: UIViewController {
                                           UIImage(resource: .imgProfileAep),
                                           UIImage(resource: .imgProfileAei)]
     
-    
     private let noFriendsEmptyView: NoFriendsEmptyView = {
         let view = NoFriendsEmptyView()
         view.isHidden = true
         return view
     }()
-    
     
     var memberData: MemberResponseStruct? {
         didSet {
@@ -72,7 +70,6 @@ final class MemberViewController: UIViewController {
             } else {
                 self.memberScrollView.isHidden = true
                 self.noFriendsEmptyView.isHidden = false
-                
             }
         }
     }
@@ -134,6 +131,12 @@ final class MemberViewController: UIViewController {
     
     private let ourTestResultView = MemberTestResultView()
     
+    private let whiteBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(resource: .white000)
+        return view
+    }()
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -167,6 +170,7 @@ private extension MemberViewController {
         view.addSubviews(navigationBar,
                          navigationUnderLineView,
                          memberScrollView,
+                         whiteBackgroundView,
                          noFriendsEmptyView)
         
         memberScrollView.addSubview(contentView)
@@ -194,6 +198,11 @@ private extension MemberViewController {
             $0.height.equalTo(1)
         }
         
+        whiteBackgroundView.snp.makeConstraints {
+            $0.top.equalTo(navigationUnderLineView.snp.bottom)
+            $0.bottom.leading.trailing.equalToSuperview()
+        }
+        
         noFriendsEmptyView.snp.makeConstraints {
             $0.top.equalTo(navigationUnderLineView.snp.bottom)
             $0.trailing.leading.equalToSuperview()
@@ -218,7 +227,7 @@ private extension MemberViewController {
             $0.width.equalTo(ScreenUtils.getWidth(327))
             $0.height.equalTo(ScreenUtils.getHeight(48))
         }
-
+        
         tasteLabelHorizStackView.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
@@ -252,7 +261,7 @@ private extension MemberViewController {
     }
     
     func registerCell() {
-        membersProfileCollectionView.register(TripFriendsCollectionViewCell.self, 
+        membersProfileCollectionView.register(TripFriendsCollectionViewCell.self,
                                               forCellWithReuseIdentifier: TripFriendsCollectionViewCell.cellIdentifier)
     }
     
@@ -297,7 +306,7 @@ extension MemberViewController: UICollectionViewDataSource {
         else { return UICollectionViewCell() }
         
         cell.friendNameLabel.text = memberData?.participants[indexPath.row].name
-
+        
         guard let memberResultNum = memberData?.participants[indexPath.row].result else { return UICollectionViewCell() }
         
         
@@ -305,7 +314,7 @@ extension MemberViewController: UICollectionViewDataSource {
             cell.profileImageView.image = userProfileImageSet[memberResultNum]
         } else {
             cell.profileImageView.image = UIImage(resource: .imgProfileGuest)
-
+            
         }
         
         return cell


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- #253 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 여행 수정뷰에서 여행 이름, 여행 시작일, 여행 종료일 중 어느 하나라도 수정 사항이 있어야만 버튼 활성화 될 수 있도록 고쳤습니다. 
- 여행취향분석뷰 (MemberVC) 진입 시, 서버통신 대기 중에 분석 뷰가 일부 노출된 후에 엠티뷰가 보이는 현상이 있었습니다.
    - 백그라운드 뷰를 깔아주는 방식으로 수정했습니다. 
    
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
N/A

## 📸 스크린샷

https://github.com/Team-Going/Going-iOS/assets/102219161/688e6f45-22e7-47d3-8dec-ac78b167a323


## 📟 관련 이슈
- Resolved: #253
