### PR TITLE
[FEAT] 2차 QA 반영 (#259)

### DIFF
--- a/Going-iOS/Global/Extensions/String+.swift
+++ b/Going-iOS/Global/Extensions/String+.swift
@@ -27,4 +27,15 @@ extension String {
         }
         return false
     }
+    
+    func getEmojiCount() -> Int {
+        var count = 0
+        
+        for scalar in unicodeScalars {
+            if scalar.properties.isEmoji {
+                count += 1
+            }
+        }
+        return count
+    }
 }

--- a/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
@@ -54,13 +54,12 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
             self.managerCollectionView.reloadData()
         }
     }
+        
+    var name: String = ""
     
-    var textWidth: CGFloat = 0 {
-        didSet {
-            self.managerCollectionView.reloadData()
-        }
-    }
-
+    var emojiCount: Int = 0
+    
+    var textWidth: CGFloat = 0
     
     // MARK: - UI Components
     
@@ -196,12 +195,13 @@ private extension MyToDoCollectionViewCell {
         label.labelWithImg(composition: attachImg, string)
     }
     
-    func getTextSize(label: UILabel) -> CGFloat {
+    func getTextSize(label: String) -> CGFloat {
         // 이모지를 고려하여 예상되는 텍스트의 크기를 얻기
-        let textSize = (label.text as NSString?)?.boundingRect(with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: label.frame.size.height),
-                                                              options: .usesLineFragmentOrigin,
-                                                              attributes: [NSAttributedString.Key.font: label.font!],
-                                                              context: nil).size
+        let textSize = (label as NSString?)?.boundingRect(with:
+                                                            CGSize(width: CGFloat.greatestFiniteMagnitude, height: 20),
+                                                            options: .usesLineFragmentOrigin,
+                                                            attributes: [NSAttributedString.Key.font: UIFont.pretendard(.detail2_regular)],
+                                                            context: nil).size
 
         let textWidth = textSize?.width ?? 0
         
@@ -233,8 +233,6 @@ extension MyToDoCollectionViewCell: UICollectionViewDataSource{
         }else {
             managerCell.managerLabel.text = self.manager[indexPath.row].name
         }
-        textWidth = getTextSize(label: managerCell.managerLabel)
-
         
         // 미완료 / 완료 / 나만보기 태그 색상 세팅
         if isComplete == true {
@@ -273,6 +271,17 @@ extension MyToDoCollectionViewCell: UICollectionViewDelegateFlowLayout {
         if myToDoData?.secret == true {
             return CGSize(width: ScreenUtils.getWidth(66), height: ScreenUtils.getHeight(20))
         } else {
+            name = myToDoData?.allocators[indexPath.row].name ?? ""
+            textWidth = getTextSize(label: name)
+            emojiCount = name.getEmojiCount()
+            
+            if name.containsEmoji() {
+                if emojiCount >= 0 {
+                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
+                }
+            } else {
+                return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
+            }
             return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
         }
     }

--- a/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
@@ -55,6 +55,12 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
         }
     }
     
+    var textWidth: CGFloat = 0 {
+        didSet {
+            self.managerCollectionView.reloadData()
+        }
+    }
+
     
     // MARK: - UI Components
     
@@ -189,6 +195,18 @@ private extension MyToDoCollectionViewCell {
         let attachImg = NSAttributedString(attachment: attachment)
         label.labelWithImg(composition: attachImg, string)
     }
+    
+    func getTextSize(label: UILabel) -> CGFloat {
+        // 이모지를 고려하여 예상되는 텍스트의 크기를 얻기
+        let textSize = (label.text as NSString?)?.boundingRect(with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: label.frame.size.height),
+                                                              options: .usesLineFragmentOrigin,
+                                                              attributes: [NSAttributedString.Key.font: label.font!],
+                                                              context: nil).size
+
+        let textWidth = textSize?.width ?? 0
+        
+        return textWidth
+    }
 }
 
 // MARK: - Extension
@@ -215,6 +233,8 @@ extension MyToDoCollectionViewCell: UICollectionViewDataSource{
         }else {
             managerCell.managerLabel.text = self.manager[indexPath.row].name
         }
+        textWidth = getTextSize(label: managerCell.managerLabel)
+
         
         // 미완료 / 완료 / 나만보기 태그 색상 세팅
         if isComplete == true {
@@ -231,6 +251,7 @@ extension MyToDoCollectionViewCell: UICollectionViewDataSource{
                 managerCell.changeLabelColor(color: UIColor(resource: .gray400))
             }
         }
+            
         return managerCell
     }
 }
@@ -252,7 +273,7 @@ extension MyToDoCollectionViewCell: UICollectionViewDelegateFlowLayout {
         if myToDoData?.secret == true {
             return CGSize(width: ScreenUtils.getWidth(66), height: ScreenUtils.getHeight(20))
         } else {
-            return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
+            return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
         }
     }
 }

--- a/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
@@ -89,6 +89,7 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
         layout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = UIColor(resource: .gray50)
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.showsVerticalScrollIndicator = false
         collectionView.isUserInteractionEnabled = true
@@ -278,14 +279,11 @@ extension MyToDoCollectionViewCell: UICollectionViewDelegateFlowLayout {
             textWidth = getTextSize(label: name)
             emojiCount = name.getEmojiCount()
             
-            if name.containsEmoji() {
-                if emojiCount >= 0 {
-                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
-                }
+            if name.containsEmoji() && emojiCount <= 3 {
+                return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
             } else {
                 return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
             }
-            return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
         }
     }
 }

--- a/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/MyToDo/Cells/MyToDoCollectionViewCell.swift
@@ -70,11 +70,13 @@ class MyToDoCollectionViewCell: UICollectionViewCell {
         return view
     }()
     
-    private let todoTitleLabel = DOOLabel(
-        font: .pretendard(.body3_medi),
-        color: UIColor(resource: .gray700),
-        alignment: .left
-    )
+    private let todoTitleLabel: DOOLabel = {
+        let label = DOOLabel(font: .pretendard(.body3_medi),
+                             color: UIColor(resource: .gray700),
+                             alignment: .left)
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }()
     
     private let deadlineLabel = DOOLabel(
         font: .pretendard(.detail3_regular),
@@ -159,6 +161,7 @@ private extension MyToDoCollectionViewCell {
         todoTitleLabel.snp.makeConstraints{
             $0.top.equalToSuperview().inset(ScreenUtils.getWidth(16))
             $0.leading.equalTo(checkButton.snp.trailing).offset(ScreenUtils.getWidth(12))
+            $0.width.equalTo(ScreenUtils.getWidth(182))
         }
         
         managerCollectionView.snp.makeConstraints{

--- a/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
@@ -54,11 +54,13 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
         return view
     }()
     
-    let todoTitleLabel: UILabel = DOOLabel(
-        font: .pretendard(.body3_medi),
-        color: UIColor(resource: .gray700),
-        alignment: .left
-    )
+    let todoTitleLabel: DOOLabel = {
+        let label = DOOLabel(font: .pretendard(.body3_medi),
+                             color: UIColor(resource: .gray700),
+                             alignment: .left)
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }()
    
     private lazy var deadlineLabel: UILabel = DOOLabel(
         font: .pretendard(.detail3_regular),
@@ -119,6 +121,7 @@ private extension OurToDoCollectionViewCell {
         }
         todoTitleLabel.snp.makeConstraints{
             $0.top.leading.equalToSuperview().inset(ScreenUtils.getWidth(16))
+            $0.width.equalTo(ScreenUtils.getWidth(212))
         }
         managerCollectionView.snp.makeConstraints{
             $0.leading.trailing.equalToSuperview().inset(ScreenUtils.getWidth(16))

--- a/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
@@ -37,6 +37,12 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
     
     var todoId: Int = 0
     
+    var textWidth: CGFloat = 0 {
+        didSet {
+            self.managerCollectionView.reloadData()
+        }
+    }
+    
     var allocators: [Allocators] = []
     
     // MARK: - UI Properties
@@ -144,6 +150,17 @@ private extension OurToDoCollectionViewCell {
         self.managerCollectionView.register(ManagerCollectionViewCell.self, forCellWithReuseIdentifier: ManagerCollectionViewCell.identifier)
     }
     
+    func getTextSize(label: UILabel) -> CGFloat {
+        // 이모지를 고려하여 예상되는 텍스트의 크기를 얻기
+        let textSize = (label.text as NSString?)?.boundingRect(with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: label.frame.size.height),
+                                                              options: .usesLineFragmentOrigin,
+                                                              attributes: [NSAttributedString.Key.font: label.font!],
+                                                              context: nil).size
+
+        let textWidth = textSize?.width ?? 0
+        
+        return textWidth
+    }
 }
 
 extension OurToDoCollectionViewCell: UICollectionViewDelegate {}
@@ -186,6 +203,8 @@ extension OurToDoCollectionViewCell: UICollectionViewDataSource {
                 }
             }
         }
+        
+        textWidth = getTextSize(label: managerCell.managerLabel)
 
         return managerCell
     }
@@ -206,12 +225,7 @@ extension OurToDoCollectionViewCell: UICollectionViewDelegateFlowLayout {
         if ourToDoData?.allocators.count == 0 {
             return CGSize(width: ScreenUtils.getWidth(94) , height: ScreenUtils.getHeight(20))
         } else {
-            let name = ourToDoData?.allocators[indexPath.row].name ?? ""
-            if name.containsEmoji() {
-                return CGSize(width: ScreenUtils.getWidth(60), height: ScreenUtils.getHeight(20))
-            } else {
-                return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
-            }       
+            return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
         }
     }
 }

--- a/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
@@ -37,11 +37,11 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
     
     var todoId: Int = 0
     
-    var textWidth: CGFloat = 0 {
-        didSet {
-            self.managerCollectionView.reloadData()
-        }
-    }
+    var name: String = ""
+    
+    var emojiCount: Int = 0
+    
+    var textWidth: CGFloat = 0
     
     var allocators: [Allocators] = []
     
@@ -70,6 +70,7 @@ final class OurToDoCollectionViewCell: UICollectionViewCell {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         collectionView.backgroundColor = .clear
         collectionView.showsVerticalScrollIndicator = false
         collectionView.isScrollEnabled = false
@@ -150,11 +151,11 @@ private extension OurToDoCollectionViewCell {
         self.managerCollectionView.register(ManagerCollectionViewCell.self, forCellWithReuseIdentifier: ManagerCollectionViewCell.identifier)
     }
     
-    func getTextSize(label: UILabel) -> CGFloat {
+    func getTextSize(label: String) -> CGFloat {
         // 이모지를 고려하여 예상되는 텍스트의 크기를 얻기
-        let textSize = (label.text as NSString?)?.boundingRect(with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: label.frame.size.height),
+        let textSize = (label as NSString?)?.boundingRect(with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: 20),
                                                               options: .usesLineFragmentOrigin,
-                                                              attributes: [NSAttributedString.Key.font: label.font!],
+                                                          attributes: [NSAttributedString.Key.font: UIFont.pretendard(.detail2_regular)],
                                                               context: nil).size
 
         let textWidth = textSize?.width ?? 0
@@ -182,7 +183,7 @@ extension OurToDoCollectionViewCell: UICollectionViewDataSource {
         
         self.todoId = self.ourToDoData?.todoId ?? 0
         self.allocators = self.ourToDoData?.allocators ?? []
-        
+                
         //담당자가 없는 경우
         if self.ourToDoData?.allocators.count == 0 {
             managerCell.isEmpty = true
@@ -204,8 +205,6 @@ extension OurToDoCollectionViewCell: UICollectionViewDataSource {
             }
         }
         
-        textWidth = getTextSize(label: managerCell.managerLabel)
-
         return managerCell
     }
 }
@@ -225,7 +224,24 @@ extension OurToDoCollectionViewCell: UICollectionViewDelegateFlowLayout {
         if ourToDoData?.allocators.count == 0 {
             return CGSize(width: ScreenUtils.getWidth(94) , height: ScreenUtils.getHeight(20))
         } else {
-            return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
+            name = ourToDoData?.allocators[indexPath.row].name ?? ""
+            textWidth = getTextSize(label: name)
+            emojiCount = name.getEmojiCount()
+            
+            if name.containsEmoji() {
+                switch emojiCount {
+                case 1 :
+                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
+                case 2:
+                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
+                case 3:
+                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
+                default :
+                    return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
+                }
+            } else {
+                return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
+            }
         }
     }
 }

--- a/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/OurToDoCollectionViewCell.swift
@@ -231,17 +231,8 @@ extension OurToDoCollectionViewCell: UICollectionViewDelegateFlowLayout {
             textWidth = getTextSize(label: name)
             emojiCount = name.getEmojiCount()
             
-            if name.containsEmoji() {
-                switch emojiCount {
-                case 1 :
-                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
-                case 2:
-                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
-                case 3:
-                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
-                default :
-                    return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
-                }
+            if name.containsEmoji() && emojiCount <= 3 {
+                return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
             } else {
                 return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
             }

--- a/Going-iOS/Scene/OurToDo/Cells/TripFriendsCollectionViewCell.swift
+++ b/Going-iOS/Scene/OurToDo/Cells/TripFriendsCollectionViewCell.swift
@@ -70,7 +70,7 @@ private extension TripFriendsCollectionViewCell {
         }
         
         profileImageView.snp.makeConstraints {
-            $0.size.equalTo(ScreenUtils.getWidth(45))
+            $0.size.equalTo(ScreenUtils.getHeight(45))
         }
 
         friendNameLabel.snp.makeConstraints{

--- a/Going-iOS/Scene/OurToDo/Views/TripMiddleView.swift
+++ b/Going-iOS/Scene/OurToDo/Views/TripMiddleView.swift
@@ -71,7 +71,7 @@ final class TripMiddleView: UIView {
     private lazy var tripFriendsCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
-        flowLayout.itemSize = CGSize(width: ScreenUtils.getHeight(48) , height: ScreenUtils.getHeight(67))
+        flowLayout.itemSize = CGSize(width: ScreenUtils.getHeight(45) , height: ScreenUtils.getHeight(67))
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         collectionView.backgroundColor = UIColor.white000
         collectionView.showsHorizontalScrollIndicator = false

--- a/Going-iOS/Scene/ToDo/ViewControllers/ActivateToDoViewController.swift
+++ b/Going-iOS/Scene/ToDo/ViewControllers/ActivateToDoViewController.swift
@@ -127,6 +127,7 @@ final class ActivateToDoViewController: UIViewController {
             if navigationBarTitle == StringLiterals.ToDo.add {
                 self.todoTextFieldView.todoTextfieldPlaceholder = value[0] as? String ?? ""
                 self.todoTextFieldView.todoTextfield.placeholder = value[0] as? String ?? ""
+                self.todoTextFieldView.todoTextfield.setPlaceholder(placeholder: value[0] as? String ?? "", fontColor: UIColor(resource: .gray200), font: UIFont.pretendard(.body3_medi))
                 self.memoTextView.memoTextviewPlaceholder = value[3] as? String ?? ""
                 self.memoTextView.memoTextView.text = value[3] as? String ?? ""
             } else {

--- a/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
+++ b/Going-iOS/Scene/ToDo/Views/MemoTextView.swift
@@ -144,7 +144,7 @@ private extension MemoTextView {
             clearButton.isEnabled = false
         } else {
             memoTextView.layer.borderColor = UIColor(resource: .gray700).cgColor
-            self.countMemoCharacterLabel.textColor = UIColor(resource: .gray400)
+            self.countMemoCharacterLabel.textColor = UIColor(resource: .gray700)
             clearButton.isHidden = false
             clearButton.isEnabled = true
         }

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -81,7 +81,7 @@ class ToDoManagerView: UIView {
                 btn.layer.borderColor = UIColor(resource: .gray300).cgColor
             }
             
-            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 3, bottom: 0, trailing: 0)
+            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
             config.attributedTitle = attributedTitle
             config.background.cornerRadius = 4
             btn.configuration = config
@@ -279,7 +279,7 @@ extension ToDoManagerView: UICollectionViewDataSource{
                         managerCell.managerButton.layer.borderColor = UIColor(resource: .red500).cgColor
                         config.background.backgroundColor = UIColor.white000
                     }
-                    config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 3, bottom: 0, trailing: 0)
+                    config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
                     
                     
                 }
@@ -354,7 +354,7 @@ extension ToDoManagerView: UICollectionViewDataSource{
                 }
             }
             config.background.cornerRadius = 4
-            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 3, bottom: 0, trailing: 0)
+            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
             config.attributedTitle = attributedTitle
             managerCell.managerButton.configuration = config
         }

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -167,10 +167,10 @@ private extension ToDoManagerView {
             switch type {
             case "secretInfoLabel" :
                 config.background.backgroundColor = .white000
-                attributedTitle.foregroundColor = UIColor.gray200
+                attributedTitle.foregroundColor = .gray200
                 button.layer.borderColor = UIColor(resource: .white000).cgColor
             case "labelWithImage" :
-                attributedTitle.foregroundColor = .red500
+                attributedTitle.foregroundColor = UIColor.red500
                 config.image = UIImage(resource: .icLock)
                 config.imagePlacement = .leading
                 config.imagePadding = 1
@@ -195,7 +195,7 @@ private extension ToDoManagerView {
             config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
             config.attributedTitle = attributedTitle
             button.configuration = config
-        }
+    }
 }
 
 
@@ -253,11 +253,7 @@ extension ToDoManagerView: UICollectionViewDataSource{
         managerCell.managerButton.isEnabled = true
         managerCell.managerButton.tag = indexPath.row
         managerCell.managerButton.addTarget(self, action: #selector(didTapToDoManagerButton(_:)), for: .touchUpInside)
-        
-        //아워투두 -> 조회
-        //다 선택된 옵션
-        //마이투두 -> 조회
-        //혼자할일 + 라벨
+
         
         //아워투두
         if beforeVC == "our" {

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -72,32 +72,25 @@ class ToDoManagerView: UIView {
             var attributedTitle = AttributedString(text)
             attributedTitle.font = .pretendard(.detail2_regular)
             if !isSelected {
-                attributedTitle.foregroundColor = UIColor.white000
-                config.background.backgroundColor = btn.tag == 0 ? UIColor.red500 : UIColor.gray400
-                btn.layer.borderColor = btn.tag == 0 ? UIColor(resource: .red500).cgColor : UIColor(resource: .gray400).cgColor
+                if btn.tag == 0 {
+                    setConfigButtonStyle(type: "allocatorRed", name: text, button: btn)
+                } else {
+                    setConfigButtonStyle(type: "allocatorGray", name: text, button: btn)
+                }
             } else {
-                attributedTitle.foregroundColor = UIColor.gray300
-                config.background.backgroundColor = UIColor.white000
-                btn.layer.borderColor = UIColor(resource: .gray300).cgColor
+                setConfigButtonStyle(type: "gray", name: text, button: btn)
             }
-            
-            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
-            config.attributedTitle = attributedTitle
-            config.background.cornerRadius = 4
-            btn.configuration = config
         } else {
             if !isSelected {
-                btn.setTitleColor(UIColor(resource: .white000), for: .normal)
-                btn.backgroundColor = btn.tag == 0 ? UIColor(resource: .red500) : UIColor(resource: .gray400)
-                btn.layer.borderColor = btn.tag == 0 ? UIColor(resource: .red500).cgColor : UIColor(resource: .gray400).cgColor
-            }else {
-                btn.setTitleColor(UIColor(resource: .gray300), for: .normal)
-                btn.backgroundColor = UIColor(resource: .white000)
-                btn.layer.borderColor = UIColor(resource: .gray300).cgColor
+                if btn.tag == 0 {
+                    setButtonStyle(type: "filledRed", button: btn)
+                } else {
+                    setButtonStyle(type: "filledGray", button: btn)
+                }
+            } else {
+                setButtonStyle(type: "gray", button: btn)
             }
         }
-        
-        
     }
     
     // 담당자 버튼 탭 시 버튼 색상 변경 & 배열에 담아주는 메서드
@@ -143,6 +136,66 @@ private extension ToDoManagerView {
         
         return textWidth
     }
+    
+    func setButtonStyle(type: String, button: UIButton) {
+        
+        switch type {
+        case "filledRed":
+            button.backgroundColor = UIColor(resource: .red500)
+            button.setTitleColor(UIColor(resource: .white000), for: .normal)
+            button.layer.borderColor = UIColor(resource: .red500).cgColor
+        case "filledGray":
+            button.backgroundColor = UIColor(resource: .gray400)
+            button.setTitleColor(UIColor(resource: .white000), for: .normal)
+            button.layer.borderColor = UIColor(resource: .gray400).cgColor
+        case "gray":
+            button.backgroundColor = UIColor(resource: .white000)
+            button.setTitleColor(UIColor(resource: .gray300), for: .normal)
+            button.layer.borderColor = UIColor(resource: .gray300).cgColor
+        default:
+            return
+        }
+    }
+    
+    func setConfigButtonStyle(type: String, name: String, button: UIButton) {
+            
+            var config = UIButton.Configuration.plain()
+
+            var attributedTitle = AttributedString(name)
+            attributedTitle.font = .pretendard(.detail2_regular)
+            
+            switch type {
+            case "secretInfoLabel" :
+                config.background.backgroundColor = .white000
+                attributedTitle.foregroundColor = UIColor.gray200
+                button.layer.borderColor = UIColor(resource: .white000).cgColor
+            case "labelWithImage" :
+                attributedTitle.foregroundColor = .red500
+                config.image = UIImage(resource: .icLock)
+                config.imagePlacement = .leading
+                config.imagePadding = 1
+                config.background.backgroundColor = .white000
+                button.layer.borderColor = UIColor(resource: .red500).cgColor
+            case "allocatorRed" :
+                config.background.backgroundColor = .red500
+                attributedTitle.foregroundColor = UIColor.white000
+                button.layer.borderColor = UIColor(resource: .red500).cgColor
+            case "allocatorGray":
+                config.background.backgroundColor = .gray400
+                attributedTitle.foregroundColor = UIColor.white000
+                button.layer.borderColor = UIColor(resource: .gray400).cgColor
+            case "gray":
+                config.background.backgroundColor = .white000
+                attributedTitle.foregroundColor = UIColor.gray300
+                button.layer.borderColor = UIColor(resource: .gray300).cgColor
+            default: return
+            }
+
+            config.background.cornerRadius = 4
+            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
+            config.attributedTitle = attributedTitle
+            button.configuration = config
+        }
 }
 
 
@@ -184,6 +237,7 @@ extension ToDoManagerView: UICollectionViewDataSource{
             } else {
                 name = allParticipants[indexPath.row].name
             }
+            managerCell.managerButton.setTitle(name, for: .normal)
         }
         //마이투두
         else {
@@ -195,19 +249,6 @@ extension ToDoManagerView: UICollectionViewDataSource{
                 name = allParticipants[indexPath.row].name
             }
         }
-        var attributedTitle = AttributedString(name)
-        
-        if beforeVC == "my" {
-            attributedTitle.font = .pretendard(.detail2_regular)
-            
-            if navigationBarTitle == StringLiterals.ToDo.add || isSecret {
-                
-                config.background.backgroundColor = .white000
-            }
-        } else {
-            managerCell.managerButton.setTitle(name, for: .normal)
-        }
-        
         
         managerCell.managerButton.isEnabled = true
         managerCell.managerButton.tag = indexPath.row
@@ -222,9 +263,7 @@ extension ToDoManagerView: UICollectionViewDataSource{
         if beforeVC == "our" {
             //아워투두 -> 추가
             if self.navigationBarTitle == StringLiterals.ToDo.add {
-                managerCell.managerButton.backgroundColor = UIColor(resource: .white000)
-                managerCell.managerButton.setTitleColor(UIColor(resource: .gray300), for: .normal)
-                managerCell.managerButton.layer.borderColor = UIColor(resource: .gray300).cgColor
+                setButtonStyle(type: "gray", button: managerCell.managerButton)
             }
             //아워투두 -> 수정 & 조회
             else {
@@ -234,22 +273,16 @@ extension ToDoManagerView: UICollectionViewDataSource{
                     
                     //담당자이면서 owner인 경우
                     if self.allParticipants[indexPath.row].isOwner {
-                        managerCell.managerButton.backgroundColor = UIColor(resource: .red500)
-                        managerCell.managerButton.setTitleColor(UIColor(resource: .white000), for: .normal)
-                        managerCell.managerButton.layer.borderColor = UIColor(resource: .red500).cgColor
+                        setButtonStyle(type: "filledRed", button: managerCell.managerButton)
                     }
                     //담당자이면서 owner가 아닌 경우
                     else {
-                        managerCell.managerButton.backgroundColor = UIColor(resource: .gray400)
-                        managerCell.managerButton.setTitleColor(UIColor(resource: .white000), for: .normal)
-                        managerCell.managerButton.layer.borderColor = UIColor(resource: .gray400).cgColor
+                        setButtonStyle(type: "filledGray", button: managerCell.managerButton)
                     }
                 }
                 //담당자로 배정되어 있지 않은 경우
                 else {
-                    managerCell.managerButton.backgroundColor = UIColor(resource: .white000)
-                    managerCell.managerButton.setTitleColor(UIColor(resource: .gray300), for: .normal)
-                    managerCell.managerButton.layer.borderColor = UIColor(resource: .gray300).cgColor
+                    setButtonStyle(type: "gray", button: managerCell.managerButton)
                 }
             }
         }
@@ -265,44 +298,36 @@ extension ToDoManagerView: UICollectionViewDataSource{
                 if self.isSecret {
                     //설명라벨 세팅
                     if allocators[indexPath.row].name == "나만 볼 수 있는 할일이에요" {
-                        attributedTitle.foregroundColor = UIColor.gray200
-                        config.background.backgroundColor = UIColor.white000
-                        managerCell.managerButton.layer.borderColor = UIColor(resource: .white000).cgColor
-                        
+                        setConfigButtonStyle(type: "secretInfoLabel", 
+                                             name: name, 
+                                             button: managerCell.managerButton)
                     } else {
-                        attributedTitle.foregroundColor = UIColor.red500
-                        
-                        config.image = UIImage(resource: .icLock)
-                        config.imagePlacement = .leading
-                        config.imagePadding = 1
-                        config.background.backgroundColor = .white000
-                        managerCell.managerButton.layer.borderColor = UIColor(resource: .red500).cgColor
-                        config.background.backgroundColor = UIColor.white000
+                        setConfigButtonStyle(type: "labelWithImage", 
+                                             name: name,
+                                             button: managerCell.managerButton)
                     }
                     config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
-                    
-                    
                 }
                 //그 외의 경우
                 else{
                     if self.allocators[indexPath.row].isAllocated {
                         //담당자이면서 owner인 경우
                         if self.allocators[indexPath.row].isOwner {
-                            config.background.backgroundColor = UIColor.red500
-                            attributedTitle.foregroundColor = UIColor.white000
-                            managerCell.managerButton.layer.borderColor = UIColor(resource: .red500).cgColor
+                            setConfigButtonStyle(type: "allocatorRed", 
+                                                 name: name,
+                                                 button: managerCell.managerButton)
                         }
                         //담당자이면서 owner가 아닌 경우
                         else {
-                            config.background.backgroundColor = UIColor.gray400
-                            attributedTitle.foregroundColor = UIColor.white000
-                            managerCell.managerButton.layer.borderColor = UIColor(resource: .gray400).cgColor
+                            setConfigButtonStyle(type: "allocatorGray", 
+                                                 name: name,
+                                                 button: managerCell.managerButton)
                         }
                     }
                     else {
-                        config.background.backgroundColor = UIColor.white000
-                        attributedTitle.foregroundColor = UIColor.gray300
-                        managerCell.managerButton.layer.borderColor = UIColor(resource: .gray300).cgColor
+                        setConfigButtonStyle(type: "gray", 
+                                             name: name,
+                                             button: managerCell.managerButton)
                     }
                 }
             }
@@ -312,15 +337,14 @@ extension ToDoManagerView: UICollectionViewDataSource{
                 //설명라벨 세팅
                 if allocators[indexPath.row].name == "나만 볼 수 있는 할일이에요" {
                     managerCell.managerButton.isEnabled = false
-                    config.background.backgroundColor = UIColor.white000
-                    managerCell.managerButton.layer.borderColor = UIColor(resource: .white000).cgColor
-                    attributedTitle.foregroundColor = UIColor.gray200
+                    setConfigButtonStyle(type: "secretInfoLabel", 
+                                         name: name,
+                                         button: managerCell.managerButton)
                 } else {
-                    managerCell.managerButton.setImage(UIImage(resource: .icLock), for: .normal)
-                    attributedTitle.foregroundColor = UIColor.red500
-                    managerCell.managerButton.layer.borderColor = UIColor(resource: .red500).cgColor
-                    config.background.backgroundColor = UIColor.white000
                     managerCell.managerButton.isUserInteractionEnabled = false
+                    setConfigButtonStyle(type: "labelWithImage", 
+                                         name: name,
+                                         button: managerCell.managerButton)
                 }
             }
             //마이투두 -> '혼자 할 일'을 제외한 수정 작업
@@ -332,33 +356,25 @@ extension ToDoManagerView: UICollectionViewDataSource{
                     managerCell.managerButton.isSelected = true
                     //담당자이면서 owner인 경우
                     if self.allParticipants[indexPath.row].isOwner {
-                        config.background.backgroundColor = UIColor.red500
-                        config.background.cornerRadius = 4
-                        attributedTitle.foregroundColor = UIColor.white000
-                        managerCell.managerButton.layer.borderColor = UIColor(resource: .red500).cgColor
+                        setConfigButtonStyle(type: "allocatorRed", 
+                                             name: name,
+                                             button: managerCell.managerButton)
                     }
                     //담당자이면서 owner가 아닌 경우
                     else {
-                        config.background.backgroundColor = UIColor.gray400
-                        config.background.cornerRadius = 4
-                        attributedTitle.foregroundColor = UIColor.white000
-                        managerCell.managerButton.layer.borderColor = UIColor(resource: .gray400).cgColor
+                        setConfigButtonStyle(type: "allocatorGray", 
+                                             name: name,
+                                             button: managerCell.managerButton)
                     }
                 }
                 //담당자가 아닌 경우
                 else {
-                    config.background.backgroundColor = UIColor.white000
-                    config.background.cornerRadius = 4
-                    attributedTitle.foregroundColor = UIColor.gray300
-                    managerCell.managerButton.layer.borderColor = UIColor(resource: .gray300).cgColor
+                    setConfigButtonStyle(type: "gray", 
+                                         name: name,
+                                         button: managerCell.managerButton)
                 }
             }
-            config.background.cornerRadius = 4
-            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
-            config.attributedTitle = attributedTitle
-            managerCell.managerButton.configuration = config
         }
-        
         return managerCell
     }
 }
@@ -386,25 +402,24 @@ extension ToDoManagerView: UICollectionViewDelegateFlowLayout {
         } else {
             
             //아워투두
-                    if beforeVC == "our" {
-                        if navigationBarTitle == StringLiterals.ToDo.add {
-                            name = fromOurTodoParticipants[indexPath.row].name
-                        }else {
-                            name = allParticipants[indexPath.row].name
-                        }
-                    }
-                    //마이투두
-                    else {
-                        //마이투두 -> '혼자 할 일'이거나 추가 작업인 경우
-                        if navigationBarTitle == StringLiterals.ToDo.add || isSecret {
-                            name = allocators[indexPath.row].name
-                        }
-                        else {
-                            name = allParticipants[indexPath.row].name
-                        }
-                    }
-
-            
+            if beforeVC == "our" {
+                if navigationBarTitle == StringLiterals.ToDo.add {
+                    name = fromOurTodoParticipants[indexPath.row].name
+                }else {
+                    name = allParticipants[indexPath.row].name
+                }
+            }
+            //마이투두
+            else {
+                //마이투두 -> '혼자 할 일'이거나 추가 작업인 경우
+                if navigationBarTitle == StringLiterals.ToDo.add || isSecret {
+                    name = allocators[indexPath.row].name
+                }
+                else {
+                    name = allParticipants[indexPath.row].name
+                }
+            }
+        
             if name.containsEmoji() {
                 textWidth = getTextSize(label: name)
                 emojiCount = name.getEmojiCount()
@@ -412,6 +427,7 @@ extension ToDoManagerView: UICollectionViewDelegateFlowLayout {
                 if emojiCount >= 0 {
                     return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
                 }
+                
             } else {
                 return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
             }

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -32,6 +32,10 @@ class ToDoManagerView: UIView {
     }()
 
     var name: String = ""
+    
+    var emojiCount: Int = 0
+    
+    var textWidth: CGFloat = 0
 
     var fromOurTodoParticipants: [Participant] = []
     
@@ -125,6 +129,19 @@ private extension ToDoManagerView {
     func setDelegate() {
         todoManagerCollectionView.delegate = self
         todoManagerCollectionView.dataSource = self
+    }
+    
+    func getTextSize(label: String) -> CGFloat {
+        // 이모지를 고려하여 예상되는 텍스트의 크기를 얻기
+        let textSize = (label as NSString?)?.boundingRect(with:
+                                                            CGSize(width: CGFloat.greatestFiniteMagnitude, height: 20),
+                                                            options: .usesLineFragmentOrigin,
+                                                            attributes: [NSAttributedString.Key.font: UIFont.pretendard(.detail2_regular)],
+                                                            context: nil).size
+
+        let textWidth = textSize?.width ?? 0
+        
+        return textWidth
     }
 }
 
@@ -389,11 +406,17 @@ extension ToDoManagerView: UICollectionViewDelegateFlowLayout {
 
             
             if name.containsEmoji() {
-                return CGSize(width: ScreenUtils.getWidth(60), height: ScreenUtils.getHeight(20))
+                textWidth = getTextSize(label: name)
+                emojiCount = name.getEmojiCount()
+                
+                if emojiCount >= 0 {
+                    return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
+                }
             } else {
                 return CGSize(width: ScreenUtils.getWidth(42), height: ScreenUtils.getHeight(20))
             }
         }
+        return CGSize(width: ScreenUtils.getWidth(textWidth + 14), height: ScreenUtils.getHeight(20))
     }
 }
 

--- a/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoManagerView.swift
@@ -381,7 +381,7 @@ extension ToDoManagerView: UICollectionViewDelegateFlowLayout {
             if indexPath.row == 0 {
                 return CGSize(width: ScreenUtils.getWidth(66), height: ScreenUtils.getHeight(20))
             } else {
-                return CGSize(width: ScreenUtils.getWidth(140), height: ScreenUtils.getHeight(18))
+                return CGSize(width: ScreenUtils.getWidth(127), height: ScreenUtils.getHeight(20))
             }
         } else {
             

--- a/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
+++ b/Going-iOS/Scene/ToDo/Views/ToDoTextFieldView.swift
@@ -31,7 +31,6 @@ class ToDoTextFieldView: UIView {
         tf.setLeftPadding(amount: 12)
         tf.clearButtonMode = .whileEditing
         tf.font = .pretendard(.body3_medi)
-        tf.setPlaceholderColor(UIColor(resource: .gray700))
         tf.textColor = UIColor(resource: .gray700)
         tf.backgroundColor = UIColor(resource: .white000)
         tf.setLeftPadding(amount: 12)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- #259

## 👷 **작업한 내용**
-  아워투두 프로필 찌부
-  특수문자만 사용해서 닉네임 설정 시 우리여행에서 이름 태그가 길게 노출
- 이모티콘 포함 닉네임 이름태그 양측 공백 폭이 다름
- 할일추가 “할일을 입력해주세요” 글씨 색이 다름
- “혼자할일” 글씨 박스 안에서 정렬
- “나만 볼 수 있는 할일이에요” 혼자할일 태그와 거리 조절
-  할일 수정에서 메모 글자수 활성화 시 색과 할일명 글자수 활성화 시 색이 다름
- 태그 색상 설정 관련 중복 코드 리팩토링

## 🚨 참고 사항
### 1. 태그 색상 설정 관련 중복 코드 리팩토링

- '우리 할 일'의 투두 내 담당자 태그 기본 색상 세팅 관련 코드가 중복되는 부분이 많아서 태그 종류에 따라 다르게 세팅할 수 있는 메소드를 만들었습니다

```swift

    func setButtonStyle(type: String, button: UIButton) {
        
        switch type {
        case "filledRed":
            button.backgroundColor = UIColor(resource: .red500)
            button.setTitleColor(UIColor(resource: .white000), for: .normal)
            button.layer.borderColor = UIColor(resource: .red500).cgColor
        case "filledGray":
            button.backgroundColor = UIColor(resource: .gray400)
            button.setTitleColor(UIColor(resource: .white000), for: .normal)
            button.layer.borderColor = UIColor(resource: .gray400).cgColor
        case "gray":
            button.backgroundColor = UIColor(resource: .white000)
            button.setTitleColor(UIColor(resource: .gray300), for: .normal)
            button.layer.borderColor = UIColor(resource: .gray300).cgColor
        default:
            return
        }
    }

```

- '나의 할 일'도 마찬가지로 태그 종류에 따라 다르게 세팅할 수 있는 메소드를 만들었습니다
- '나의 할 일'에서는 자물쇠 이미지를 적용할 때 setImage를 사용했더니 색상이 이상해져서 configuration을 사용해서 해결했습니다

```swift

       func setConfigButtonStyle(type: String, name: String, button: UIButton) {
            
            var config = UIButton.Configuration.plain()

            var attributedTitle = AttributedString(name)
            attributedTitle.font = .pretendard(.detail2_regular)
            
            switch type {
            case "secretInfoLabel" :
                config.background.backgroundColor = .white000
                attributedTitle.foregroundColor = UIColor.gray200
                button.layer.borderColor = UIColor(resource: .white000).cgColor
            case "labelWithImage" :
                attributedTitle.foregroundColor = UIColor.red500
                config.image = UIImage(resource: .icLock)
                config.imagePlacement = .leading
                config.imagePadding = 1
                config.background.backgroundColor = .white000
                button.layer.borderColor = UIColor(resource: .red500).cgColor
            ...
            default: return
            }

            config.background.cornerRadius = 4
            config.contentInsets = NSDirectionalEdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
            config.attributedTitle = attributedTitle
            button.configuration = config
    }

```
### 2. 색상 관련 새롭게 알게된 점...? 아직 정확히 잘 모르는 점🥹

- Button Configuration을 사용하여 버튼의 백그라운드 색상을 지정해줄 때 `UIColor.white000` 이런 식으로 UIColor 클래스를 직접 참조해서 지정하면 적용되지 않고 그냥 `.white000` 이런 식으로 지정해줘야지 적용이 됩니다
- Button Configuration을 사용하여 버튼의 폰트 색상을 지정해줄 때 AttributedString의 foregroundColor 속성을 사용하는데,`UIColor.white000` 이런 식으로 UIColor 클래스를 직접 참조해서 지정해야 적용되고 그냥 `.white000` 이런 식으로 지정해주면 적용이 안됩니다
- 억까인가,,,? 왜 그러는지 아시는 분 알려주세요🥹



## 📟 관련 이슈
- Resolved: #259 
